### PR TITLE
Add cargo-binstall release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install cross
         env:
           RUSTFLAGS: ""
-        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 88f49ff79e777bef6d3564531636ee4d3cc2f8d2
       - name: Cache cargo registry
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
               echo "Uploading ${file}"
               gh release upload "${{ github.ref_name }}" "$file" --clobber
               uploaded_count=$((uploaded_count + 1))
-              echo "metric=release_asset_uploaded count=${uploaded_count} file=${file}"
+              echo "metric=release_asset_uploaded count=${uploaded_count}"
             done
           done
           echo "Uploaded ${uploaded_count} release assets."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,11 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Python 3.13
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.13'
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
       - name: Verify tag matches Cargo.toml
         env:
           INPUT_CARGO_TOML_PATH: ${{ env.CARGO_TOML_PATH }}
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
       - name: Cache cross binary
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.cargo/bin/cross
           key: cross-v0.2.5-${{ runner.os }}
@@ -60,7 +60,7 @@ jobs:
           RUSTFLAGS: ""
         run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.cargo/registry
@@ -86,7 +86,7 @@ jobs:
           set -euo pipefail
           uv run scripts/release_support.py prepare-artifact
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}
           path: artifacts/${{ matrix.os }}-${{ matrix.arch }}
@@ -98,10 +98,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           generate_release_notes: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           path: artifacts
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,10 @@ jobs:
       - name: Add release target
         run: rustup target add ${{ matrix.target }}
       - name: Build release binary
-        run: cross build --release --target ${{ matrix.target }} --package ${{ env.PACKAGE_NAME }} --bin ${{ env.PACKAGE_NAME }}
+        run: |
+          set -euo pipefail
+          cross build --release --target ${{ matrix.target }} --package ${{ env.PACKAGE_NAME }} --bin ${{ env.PACKAGE_NAME }}
+          echo "metric=release_build_complete target=${{ matrix.target }} os=${{ matrix.os }} arch=${{ matrix.arch }}"
       - name: Prepare artifact
         env:
           INPUT_PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
@@ -112,6 +115,7 @@ jobs:
               echo "Uploading ${file}"
               gh release upload "${{ github.ref_name }}" "$file" --clobber
               uploaded_count=$((uploaded_count + 1))
+              echo "metric=release_asset_uploaded count=${uploaded_count} file=${file}"
             done
           done
           echo "Uploaded ${uploaded_count} release assets."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,19 +83,23 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           artifact_dir="artifacts/${{ matrix.os }}-${{ matrix.arch }}"
           binary_path="target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }}${{ matrix.ext }}"
-          binary_name="${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}"
+          binary_name="${{ env.PACKAGE_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}"
 
           mkdir -p "${artifact_dir}"
           cp "${binary_path}" "${artifact_dir}/${binary_name}"
-          sha256sum "${artifact_dir}/${binary_name}" > \
-            "${artifact_dir}/${binary_name}.sha256"
+          (
+            cd "${artifact_dir}"
+            sha256sum "${binary_name}" > "${binary_name}.sha256"
+          )
 
           if [ "${{ matrix.cargo_binstall_archive }}" = "true" ]; then
-            archive_name="${{ env.REPO_NAME }}-${version}-${{ matrix.target }}.tar.gz"
+            archive_name="${{ env.PACKAGE_NAME }}-${version}-${{ matrix.target }}.tar.gz"
             tar -C "target/${{ matrix.target }}/release" -czf \
               "${artifact_dir}/${archive_name}" "${{ env.PACKAGE_NAME }}${{ matrix.ext }}"
-            sha256sum "${artifact_dir}/${archive_name}" > \
-              "${artifact_dir}/${archive_name}.sha256"
+            (
+              cd "${artifact_dir}"
+              sha256sum "${archive_name}" > "${archive_name}.sha256"
+            )
           fi
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
@@ -106,6 +110,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - uses: softprops/action-gh-release@v2
@@ -117,7 +123,7 @@ jobs:
       - run: |
           for dir in artifacts/${{ env.REPO_NAME }}-*; do
             for file in "$dir"/*; do
-              gh release upload "${{ github.ref_name }}" "$file"
+              gh release upload "${{ github.ref_name }}" "$file" --clobber
             done
           done
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Release Binary
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  CARGO_TOML_PATH: crates/dear-diary/Cargo.toml
+  PACKAGE_NAME: dear-diary
+  REPO_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            ext: ""
+            cargo_binstall_archive: true
+          - os: linux
+            arch: aarch64
+            target: aarch64-unknown-linux-gnu
+            ext: ""
+            cargo_binstall_archive: true
+          - os: freebsd
+            arch: x86_64
+            target: x86_64-unknown-freebsd
+            ext: ""
+            cargo_binstall_archive: false
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Setup Python 3.11
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Verify tag matches Cargo.toml
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          cargo_version="$("${{ steps.setup-python.outputs.python-path }}" -c 'import os, pathlib, tomllib; root = tomllib.loads(pathlib.Path("Cargo.toml").read_text(encoding="utf-8")); package = tomllib.loads(pathlib.Path(os.environ["CARGO_TOML_PATH"]).read_text(encoding="utf-8")); version = package["package"].get("version"); print(root["workspace"]["package"]["version"] if isinstance(version, dict) and version.get("workspace") else version)')"
+          if [ -z "${cargo_version:-}" ]; then
+            echo "::error title=Cargo.toml parse failure::Could not read package.version from ${CARGO_TOML_PATH} or workspace.package.version from Cargo.toml."
+            exit 1
+          fi
+          if [ "$tag" != "$cargo_version" ]; then
+            echo "::error title=Tag/Cargo.toml mismatch::Tag version $tag does not match Cargo.toml version $cargo_version"
+            exit 1
+          fi
+          echo "Release tag $tag matches Cargo.toml version."
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - name: Cache cross binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cross
+          key: cross-v0.2.5-${{ runner.os }}
+      - name: Install cross
+        env:
+          RUSTFLAGS: ""
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Add release target
+        run: rustup target add ${{ matrix.target }}
+      - name: Build release binary
+        run: cross build --release --target ${{ matrix.target }} --package ${{ env.PACKAGE_NAME }} --bin ${{ env.PACKAGE_NAME }}
+      - name: Prepare artifact
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          artifact_dir="artifacts/${{ matrix.os }}-${{ matrix.arch }}"
+          binary_path="target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }}${{ matrix.ext }}"
+          binary_name="${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}"
+
+          mkdir -p "${artifact_dir}"
+          cp "${binary_path}" "${artifact_dir}/${binary_name}"
+          sha256sum "${artifact_dir}/${binary_name}" > \
+            "${artifact_dir}/${binary_name}.sha256"
+
+          if [ "${{ matrix.cargo_binstall_archive }}" = "true" ]; then
+            archive_name="${{ env.REPO_NAME }}-${version}-${{ matrix.target }}.tar.gz"
+            tar -C "target/${{ matrix.target }}/release" -czf \
+              "${artifact_dir}/${archive_name}" "${{ env.PACKAGE_NAME }}${{ matrix.ext }}"
+            sha256sum "${artifact_dir}/${archive_name}" > \
+              "${artifact_dir}/${archive_name}.sha256"
+          fi
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.REPO_NAME }}-${{ matrix.os }}-${{ matrix.arch }}
+          path: artifacts/${{ matrix.os }}-${{ matrix.arch }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - run: |
+          for dir in artifacts/${{ env.REPO_NAME }}-*; do
+            for file in "$dir"/*; do
+              gh release upload "${{ github.ref_name }}" "$file"
+            done
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,25 +33,21 @@ jobs:
             cargo_binstall_archive: false
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - name: Setup Python 3.11
+      - name: Setup Python 3.13
         id: setup-python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
       - name: Verify tag matches Cargo.toml
+        env:
+          INPUT_CARGO_TOML_PATH: ${{ env.CARGO_TOML_PATH }}
+          INPUT_GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME#v}"
-          cargo_version="$("${{ steps.setup-python.outputs.python-path }}" -c 'import os, pathlib, tomllib; root = tomllib.loads(pathlib.Path("Cargo.toml").read_text(encoding="utf-8")); package = tomllib.loads(pathlib.Path(os.environ["CARGO_TOML_PATH"]).read_text(encoding="utf-8")); version = package["package"].get("version"); print(root["workspace"]["package"]["version"] if isinstance(version, dict) and version.get("workspace") else version)')"
-          if [ -z "${cargo_version:-}" ]; then
-            echo "::error title=Cargo.toml parse failure::Could not read package.version from ${CARGO_TOML_PATH} or workspace.package.version from Cargo.toml."
-            exit 1
-          fi
-          if [ "$tag" != "$cargo_version" ]; then
-            echo "::error title=Tag/Cargo.toml mismatch::Tag version $tag does not match Cargo.toml version $cargo_version"
-            exit 1
-          fi
-          echo "Release tag $tag matches Cargo.toml version."
+          "${{ steps.setup-python.outputs.python-path }}" --version
+          uv run scripts/release_support.py verify-version
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
       - name: Cache cross binary
@@ -78,29 +74,17 @@ jobs:
       - name: Build release binary
         run: cross build --release --target ${{ matrix.target }} --package ${{ env.PACKAGE_NAME }} --bin ${{ env.PACKAGE_NAME }}
       - name: Prepare artifact
+        env:
+          INPUT_PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+          INPUT_VERSION: ${{ github.ref_name }}
+          INPUT_TARGET: ${{ matrix.target }}
+          INPUT_OS: ${{ matrix.os }}
+          INPUT_ARCH: ${{ matrix.arch }}
+          INPUT_EXT: ${{ matrix.ext }}
+          INPUT_CARGO_BINSTALL_ARCHIVE: ${{ matrix.cargo_binstall_archive }}
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          artifact_dir="artifacts/${{ matrix.os }}-${{ matrix.arch }}"
-          binary_path="target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }}${{ matrix.ext }}"
-          binary_name="${{ env.PACKAGE_NAME }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}"
-
-          mkdir -p "${artifact_dir}"
-          cp "${binary_path}" "${artifact_dir}/${binary_name}"
-          (
-            cd "${artifact_dir}"
-            sha256sum "${binary_name}" > "${binary_name}.sha256"
-          )
-
-          if [ "${{ matrix.cargo_binstall_archive }}" = "true" ]; then
-            archive_name="${{ env.PACKAGE_NAME }}-${version}-${{ matrix.target }}.tar.gz"
-            tar -C "target/${{ matrix.target }}/release" -czf \
-              "${artifact_dir}/${archive_name}" "${{ env.PACKAGE_NAME }}${{ matrix.ext }}"
-            (
-              cd "${artifact_dir}"
-              sha256sum "${archive_name}" > "${archive_name}.sha256"
-            )
-          fi
+          uv run scripts/release_support.py prepare-artifact
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
@@ -121,10 +105,15 @@ jobs:
         with:
           path: artifacts
       - run: |
+          uploaded_count=0
           for dir in artifacts/${{ env.REPO_NAME }}-*; do
+            echo "Uploading release assets from ${dir}"
             for file in "$dir"/*; do
+              echo "Uploading ${file}"
               gh release upload "${{ github.ref_name }}" "$file" --clobber
+              uploaded_count=$((uploaded_count + 1))
             done
           done
+          echo "Uploaded ${uploaded_count} release assets."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
-PYTEST ?= uv run --with pytest --with cyclopts python -m pytest
+PYTEST ?= uv run --with pytest --with cyclopts --with syrupy python -m pytest
 
 build: target/debug/$(TARGET) ## Build debug binary
 release: target/release/$(TARGET) ## Build release binary

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
+.PHONY: help all clean test test-scripts build release lint fmt check-fmt markdownlint nixie
 
 
 TARGET ?= dear-diary
@@ -12,17 +12,21 @@ CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
+PYTEST ?= uv run --with pytest --with cyclopts python -m pytest
 
 build: target/debug/$(TARGET) ## Build debug binary
 release: target/release/$(TARGET) ## Build release binary
 
-all: check-fmt lint test ## Perform a comprehensive check of code
+all: check-fmt lint test test-scripts ## Perform a comprehensive check of code
 
 clean: ## Remove build artifacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test $(TEST_FLAGS) $(BUILD_JOBS)
+
+test-scripts: ## Run Python script tests
+	$(PYTEST) scripts/tests
 
 target/%/$(TARGET): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(TARGET)

--- a/crates/dear-diary/Cargo.toml
+++ b/crates/dear-diary/Cargo.toml
@@ -6,6 +6,13 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.binstall]
+
+[package.metadata.binstall.overrides.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"), target_env = "gnu"))']
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.tar.gz"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [dependencies]
 dear-diary-config.workspace = true
 dear-diary-embeddings.workspace = true

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,0 +1,61 @@
+# Developer guide
+
+This guide covers release automation and local validation for contributors.
+
+## Release workflow
+
+The release workflow is defined in `.github/workflows/release.yml`. It runs
+when a tag matching `v<major>.<minor>.<patch>` is pushed.
+
+The workflow builds the `dear-diary` binary package for the configured target
+matrix. Linux GNU release targets also produce `cargo-binstall` archives whose
+names match the `[package.metadata.binstall]` configuration in
+`crates/dear-diary/Cargo.toml`.
+
+The release job declares `contents: write` because it creates or updates the
+GitHub release and uploads release assets. Asset uploads use `--clobber` so a
+rerun replaces existing files instead of failing on duplicates.
+
+## Release helper script
+
+Release version checks, artefact copying, archive generation, and checksum
+creation live in `scripts/release_support.py`. Keep this logic in the script
+rather than embedding it directly in workflow shell blocks so it remains
+testable.
+
+The script follows the repository scripting standards:
+
+- `uv` executes the script with its declared Python dependencies.
+- Cyclopts maps `INPUT_*` workflow environment variables to typed parameters.
+- Pure helper functions handle version resolution, tag validation, archive
+  creation, and checksum manifest creation.
+
+Run the script tests with:
+
+```bash
+make test-scripts
+```
+
+The tests verify workspace-inherited Cargo versions, tag/version matching,
+`cargo-binstall` metadata, archive layout, and checksum manifests that contain
+only asset basenames.
+
+GitHub Actions installs `uv` with `astral-sh/setup-uv` before running the
+release helper. The helper targets Python 3.13, matching the repository
+scripting standards for new automation.
+
+## Release artefacts
+
+Each matrix build writes artefacts under `artifacts/<os>-<arch>`. The uploaded
+binary uses the package-name-based pattern `dear-diary-<os>-<arch>`.
+
+For Linux GNU `cargo-binstall` targets, the helper also creates:
+
+```plaintext
+dear-diary-<version>-<target>.tar.gz
+dear-diary-<version>-<target>.tar.gz.sha256
+```
+
+The archive contains the `dear-diary` executable at the archive root. Checksum
+files contain only the asset basename, so downstream users can run
+`sha256sum -c` from the download directory.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -19,10 +19,16 @@ rerun replaces existing files instead of failing on duplicates.
 ## Release helper script
 
 Release version checks live in `scripts/release_version.py`. Artefact copying,
-archive generation, and checksum creation live in `scripts/release_packaging.py`.
-The `scripts/release_support.py` script keeps the command-line wiring thin.
-Keep this logic in scripts rather than embedding it directly in workflow shell
-blocks so it remains testable.
+archive generation, and checksum creation live in
+`scripts/release_packaging.py`. The `scripts/release_support.py` script keeps
+the command-line wiring thin. Keep this logic in scripts rather than embedding
+it directly in workflow shell blocks so it remains testable.
+
+The helper is split across focused modules to keep each file comfortably under
+the project size limit and to make command wiring, manifest validation, and
+packaging side effects independently reviewable. Release automation also pins
+external Git references rather than using floating tags; for example, the
+workflow installs `cross` from a fixed revision so reruns use the same source.
 
 The script follows the repository scripting standards:
 
@@ -38,8 +44,10 @@ make test-scripts
 ```
 
 The tests verify workspace-inherited Cargo versions, tag/version matching,
-`cargo-binstall` metadata, archive layout, and checksum manifests that contain
-only asset basenames.
+Cyclopts environment mapping, GitHub Actions upload wiring, `cargo-binstall`
+metadata, archive layout, and checksum manifests that contain only asset
+basenames. Snapshot tests pin the command output shape for the release helper
+commands.
 
 GitHub Actions installs `uv` with `astral-sh/setup-uv` before running the
 release helper. The helper targets Python 3.13, matching the repository

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -18,17 +18,18 @@ rerun replaces existing files instead of failing on duplicates.
 
 ## Release helper script
 
-Release version checks, artefact copying, archive generation, and checksum
-creation live in `scripts/release_support.py`. Keep this logic in the script
-rather than embedding it directly in workflow shell blocks so it remains
-testable.
+Release version checks live in `scripts/release_version.py`. Artefact copying,
+archive generation, and checksum creation live in `scripts/release_packaging.py`.
+The `scripts/release_support.py` script keeps the command-line wiring thin.
+Keep this logic in scripts rather than embedding it directly in workflow shell
+blocks so it remains testable.
 
 The script follows the repository scripting standards:
 
 - `uv` executes the script with its declared Python dependencies.
 - Cyclopts maps `INPUT_*` workflow environment variables to typed parameters.
-- Pure helper functions handle version resolution, tag validation, archive
-  creation, and checksum manifest creation.
+- Pure helper functions in focused modules handle version resolution, tag
+  validation, archive creation, and checksum manifest creation.
 
 Run the script tests with:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,4 +1,4 @@
-# Release Process
+# Release process
 
 This project publishes prebuilt binaries for multiple operating systems and
 architectures. It also publishes `cargo-binstall` archives for the supported

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,48 @@
+# Release Process
+
+This project publishes prebuilt binaries for multiple operating systems and
+architectures. It also publishes `cargo-binstall` archives for the supported
+Linux release targets.
+
+The project uses the Rust toolchain pinned in `rust-toolchain.toml`.
+
+The GitHub Actions workflow `.github/workflows/release.yml` builds and uploads
+binaries for:
+
+- Linux (x86_64 and aarch64)
+- FreeBSD (x86_64)
+
+Releases start from tags named `v<major>.<minor>.<patch>`. The workflow checks
+that the tag's version, without the leading `v`, matches the workspace
+`Cargo.toml` version field and aborts if they differ.
+
+Each binary is named using the pattern `dear-diary-<os>-<arch>`.
+
+For Linux `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`, the
+workflow also produces `cargo-binstall` archives named
+`dear-diary-<version>-<target>.tar.gz`. Each archive contains the
+`dear-diary` binary at the archive root, matching the
+`crates/dear-diary/Cargo.toml` `[package.metadata.binstall]` configuration.
+
+Binaries are uploaded as soon as they are built, so they are available from the
+workflow run while other targets build.
+
+## Workflow details
+
+The `release.yml` workflow defines a matrix of operating system and
+architecture combinations. Each entry includes the target triple used by
+`cross` and whether the target also needs a `cargo-binstall` archive. During
+the build job, `cross` compiles the `dear-diary` package release binary for
+every matrix row.
+
+`cross` is installed from a specific git tag to avoid unexpected behaviour from
+its main branch. Each binary is placed in an `artifacts/<os>-<arch>` directory
+using the naming pattern `dear-diary-<os>-<arch>`. An SHA-256 checksum is
+written alongside each binary for download verification. The Linux
+`cargo-binstall` targets additionally produce
+`dear-diary-<version>-<target>.tar.gz` plus a matching SHA-256 checksum.
+
+After every build completes, the artefact is uploaded so that the GitHub
+Actions interface provides it immediately. Once the matrix has finished, the
+`release` job downloads all artefacts and uploads them to the GitHub release
+using `gh release upload`.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -32,6 +32,12 @@ On supported Linux GNU targets, install the prebuilt release archive with
 `cargo-binstall`:
 
 ```bash
+cargo install cargo-binstall
+```
+
+Then install Dear Diary:
+
+```bash
 cargo binstall dear-diary
 ```
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -26,6 +26,18 @@ Before installing Dear Diary, ensure the following requirements are met:
 
 ## Installation
 
+### Installing with cargo-binstall
+
+On supported Linux GNU targets, install the prebuilt release archive with
+`cargo-binstall`:
+
+```bash
+cargo binstall dear-diary
+```
+
+The release workflow publishes `cargo-binstall` archives for Linux x86_64 and
+aarch64 targets. For other targets, build from source.
+
 ### Building from source
 
 Clone the repository and build the release binary:

--- a/scripts/release_packaging.py
+++ b/scripts/release_packaging.py
@@ -25,10 +25,13 @@ Prepare one Linux release artefact set::
 from __future__ import annotations
 
 import hashlib
+import logging
 import shutil
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
+
+logger = logging.getLogger("release_support.packaging")
 
 
 @dataclass(frozen=True)
@@ -131,9 +134,15 @@ def write_sha256_manifest(path: Path) -> Path:
     >>> manifest.name
     'dear-diary-linux-x86_64.sha256'
     """
+    logger.info("operation=write_sha256_manifest phase=start path=%s", path)
     digest = hashlib.sha256(path.read_bytes()).hexdigest()
     manifest_path = path.with_name(f"{path.name}.sha256")
     manifest_path.write_text(f"{digest}  {path.name}\n", encoding="utf-8")
+    logger.info(
+        "operation=write_sha256_manifest phase=complete path=%s manifest=%s",
+        path,
+        manifest_path,
+    )
     return manifest_path
 
 
@@ -182,6 +191,18 @@ def prepare_artifacts(request: ArtifactRequest) -> list[Path]:
     >>> len(outputs)  # doctest: +SKIP
     4
     """
+    logger.info(
+        (
+            "operation=prepare_artifacts phase=start project_root=%s package=%s "
+            "target=%s os=%s arch=%s binstall=%s"
+        ),
+        request.project_root,
+        request.package_name,
+        request.target,
+        request.os_name,
+        request.arch,
+        request.cargo_binstall_archive,
+    )
     artifact_dir = request.project_root / "artifacts" / (
         f"{request.os_name}-{request.arch}"
     )
@@ -196,6 +217,11 @@ def prepare_artifacts(request: ArtifactRequest) -> list[Path]:
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
     copied_binary = artifact_dir / binary_name
+    logger.info(
+        "operation=prepare_artifacts phase=copy source=%s destination=%s",
+        binary_path,
+        copied_binary,
+    )
     shutil.copy2(binary_path, copied_binary)
 
     outputs = [copied_binary, write_sha256_manifest(copied_binary)]
@@ -203,7 +229,21 @@ def prepare_artifacts(request: ArtifactRequest) -> list[Path]:
         archive_path = artifact_dir / (
             f"{request.package_name}-{request.version}-{request.target}.tar.gz"
         )
+        logger.info(
+            "operation=prepare_artifacts phase=archive source=%s archive=%s",
+            binary_path,
+            archive_path,
+        )
         with tarfile.open(archive_path, "w:gz") as archive:
             archive.add(binary_path, arcname=f"{request.package_name}{request.ext}")
         outputs.extend([archive_path, write_sha256_manifest(archive_path)])
+    else:
+        logger.info(
+            "operation=prepare_artifacts phase=skip_archive reason=binstall_disabled target=%s",
+            request.target,
+        )
+    logger.info(
+        "operation=prepare_artifacts phase=complete metric=generated_outputs count=%d",
+        len(outputs),
+    )
     return outputs

--- a/scripts/release_packaging.py
+++ b/scripts/release_packaging.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger("release_support.packaging")
+CHUNK_SIZE = 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -135,7 +136,11 @@ def write_sha256_manifest(path: Path) -> Path:
     'dear-diary-linux-x86_64.sha256'
     """
     logger.info("operation=write_sha256_manifest phase=start path=%s", path)
-    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    hasher = hashlib.sha256()
+    with path.open("rb") as artefact:
+        for chunk in iter(lambda: artefact.read(CHUNK_SIZE), b""):
+            hasher.update(chunk)
+    digest = hasher.hexdigest()
     manifest_path = path.with_name(f"{path.name}.sha256")
     manifest_path.write_text(f"{digest}  {path.name}\n", encoding="utf-8")
     logger.info(

--- a/scripts/release_packaging.py
+++ b/scripts/release_packaging.py
@@ -1,0 +1,209 @@
+"""Release artefact packaging helpers.
+
+This module prepares copied release binaries, SHA-256 manifests, and optional
+`cargo-binstall` tarballs. It is intentionally independent of Cyclopts and
+GitHub Actions so tests can exercise filesystem behaviour directly.
+
+Examples
+--------
+Prepare one Linux release artefact set::
+
+    from pathlib import Path
+    request = ArtifactRequest(
+        project_root=Path("."),
+        package_name="dear-diary",
+        version="0.1.0",
+        target="x86_64-unknown-linux-gnu",
+        os_name="linux",
+        arch="x86_64",
+        ext="",
+        cargo_binstall_archive=True,
+    )
+    outputs = prepare_artifacts(request)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ArtifactRequest:
+    """Configuration required to prepare one release artefact set.
+
+    Parameters
+    ----------
+    project_root : pathlib.Path
+        Repository root containing `target/` and receiving `artifacts/`.
+    package_name : str
+        Cargo package and binary name, for example `dear-diary`.
+    version : str
+        Release version without the leading `v`.
+    target : str
+        Rust target triple used for the release build.
+    os_name : str
+        Operating system label used in the uploaded binary name.
+    arch : str
+        Architecture label used in the uploaded binary name.
+    ext : str
+        Platform executable suffix, such as `.exe` on Windows or an empty
+        string on Unix targets.
+    cargo_binstall_archive : bool
+        Whether to create a `cargo-binstall` tarball alongside the binary.
+
+    Returns
+    -------
+    ArtifactRequest
+        Immutable request object consumed by :func:`prepare_artifacts`.
+
+    Raises
+    ------
+    None
+        Dataclass construction performs no filesystem validation.
+
+    Notes
+    -----
+    `prepare_artifacts` performs the filesystem side effects described by this
+    request.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> request = ArtifactRequest(
+    ...     project_root=Path("."),
+    ...     package_name="dear-diary",
+    ...     version="0.1.0",
+    ...     target="x86_64-unknown-linux-gnu",
+    ...     os_name="linux",
+    ...     arch="x86_64",
+    ...     ext="",
+    ...     cargo_binstall_archive=True,
+    ... )
+    >>> request.package_name
+    'dear-diary'
+    """
+
+    project_root: Path
+    package_name: str
+    version: str
+    target: str
+    os_name: str
+    arch: str
+    ext: str
+    cargo_binstall_archive: bool
+
+
+def write_sha256_manifest(path: Path) -> Path:
+    """Write a SHA-256 manifest containing only the artefact basename.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Artefact file to hash.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the `.sha256` manifest written next to `path`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If `path` does not exist.
+    OSError
+        If the artefact cannot be read or the manifest cannot be written.
+
+    Notes
+    -----
+    This function writes a sibling file as a side effect. The manifest uses the
+    artefact basename so users can run `sha256sum -c` from the download
+    directory.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> path = Path("artifacts/linux-x86_64/dear-diary-linux-x86_64")
+    >>> manifest = write_sha256_manifest(path)
+    >>> manifest.name
+    'dear-diary-linux-x86_64.sha256'
+    """
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    manifest_path = path.with_name(f"{path.name}.sha256")
+    manifest_path.write_text(f"{digest}  {path.name}\n", encoding="utf-8")
+    return manifest_path
+
+
+def prepare_artifacts(request: ArtifactRequest) -> list[Path]:
+    """Prepare release binaries, checksums, and optional binstall archives.
+
+    Parameters
+    ----------
+    request : ArtifactRequest
+        Release artefact preparation request.
+
+    Returns
+    -------
+    list[pathlib.Path]
+        Paths to every generated artefact and checksum manifest.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the release binary for `request.target` is missing.
+    OSError
+        If artefact directories, copied binaries, archives, or checksum
+        manifests cannot be created.
+    tarfile.TarError
+        If the `cargo-binstall` archive cannot be written.
+
+    Notes
+    -----
+    This function creates files under `artifacts/<os>-<arch>` and may
+    overwrite existing artefacts with the same names.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> request = ArtifactRequest(
+    ...     project_root=Path("."),
+    ...     package_name="dear-diary",
+    ...     version="0.1.0",
+    ...     target="x86_64-unknown-linux-gnu",
+    ...     os_name="linux",
+    ...     arch="x86_64",
+    ...     ext="",
+    ...     cargo_binstall_archive=True,
+    ... )
+    >>> outputs = prepare_artifacts(request)  # doctest: +SKIP
+    >>> len(outputs)  # doctest: +SKIP
+    4
+    """
+    artifact_dir = request.project_root / "artifacts" / (
+        f"{request.os_name}-{request.arch}"
+    )
+    binary_path = (
+        request.project_root
+        / "target"
+        / request.target
+        / "release"
+        / f"{request.package_name}{request.ext}"
+    )
+    binary_name = f"{request.package_name}-{request.os_name}-{request.arch}{request.ext}"
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    copied_binary = artifact_dir / binary_name
+    shutil.copy2(binary_path, copied_binary)
+
+    outputs = [copied_binary, write_sha256_manifest(copied_binary)]
+    if request.cargo_binstall_archive:
+        archive_path = artifact_dir / (
+            f"{request.package_name}-{request.version}-{request.target}.tar.gz"
+        )
+        with tarfile.open(archive_path, "w:gz") as archive:
+            archive.add(binary_path, arcname=f"{request.package_name}{request.ext}")
+        outputs.extend([archive_path, write_sha256_manifest(archive_path)])
+    return outputs

--- a/scripts/release_support.py
+++ b/scripts/release_support.py
@@ -3,25 +3,23 @@
 # requires-python = ">=3.13"
 # dependencies = ["cyclopts>=2.9"]
 # ///
-"""Release workflow helpers for Dear Diary binary artefacts.
+"""Command-line interface for Dear Diary release helpers.
 
-This module contains the testable parts of the GitHub release workflow:
-Cargo manifest version resolution, tag validation, release binary copying,
-`cargo-binstall` archive creation, and SHA-256 manifest generation. The
-workflow calls the Cyclopts commands directly through `uv`, while tests import
-the pure helper functions.
+This module keeps GitHub Actions wiring thin. Version parsing lives in
+`release_version`, and artefact packaging lives in `release_packaging`; this
+file only maps `INPUT_*` environment variables to those helpers.
 
-Typical usage is from GitHub Actions with `INPUT_*` environment variables.
+Typical usage is from GitHub Actions with `uv`.
 
 Examples
 --------
-Verify that a tag matches the installable crate version::
+Verify the release tag against the installable package manifest::
 
     INPUT_CARGO_TOML_PATH=crates/dear-diary/Cargo.toml \\
     INPUT_GITHUB_REF_NAME=v0.1.0 \\
     uv run scripts/release_support.py verify-version
 
-Prepare one Linux release artefact set::
+Prepare one release artefact set::
 
     INPUT_PACKAGE_NAME=dear-diary INPUT_VERSION=v0.1.0 \\
     INPUT_TARGET=x86_64-unknown-linux-gnu INPUT_OS=linux \\
@@ -31,285 +29,16 @@ Prepare one Linux release artefact set::
 
 from __future__ import annotations
 
-import hashlib
-import os
-import shutil
-import tarfile
-import tomllib
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
 
 import cyclopts
 from cyclopts import App, Parameter
 
+from release_packaging import ArtifactRequest, prepare_artifacts
+from release_version import assert_tag_matches_version, load_package_version
+
 app = App(config=cyclopts.config.Env("INPUT_", command=False))
-
-
-@dataclass(frozen=True)
-class ArtifactRequest:
-    """Configuration required to prepare one release artefact set.
-
-    Parameters
-    ----------
-    project_root : pathlib.Path
-        Repository root containing `target/` and receiving `artifacts/`.
-    package_name : str
-        Cargo package and binary name, for example `dear-diary`.
-    version : str
-        Release version without the leading `v`.
-    target : str
-        Rust target triple used for the release build.
-    os_name : str
-        Operating system label used in the uploaded binary name.
-    arch : str
-        Architecture label used in the uploaded binary name.
-    ext : str
-        Platform executable suffix, such as `.exe` on Windows or an empty
-        string on Unix targets.
-    cargo_binstall_archive : bool
-        Whether to create a `cargo-binstall` tarball alongside the binary.
-
-    Returns
-    -------
-    ArtifactRequest
-        Immutable request object consumed by :func:`prepare_artifacts`.
-
-    Raises
-    ------
-    None
-        Dataclass construction performs no filesystem validation.
-
-    Notes
-    -----
-    `prepare_artifacts` performs the filesystem side effects described by this
-    request.
-
-    Examples
-    --------
-    >>> from pathlib import Path
-    >>> request = ArtifactRequest(
-    ...     project_root=Path("."),
-    ...     package_name="dear-diary",
-    ...     version="0.1.0",
-    ...     target="x86_64-unknown-linux-gnu",
-    ...     os_name="linux",
-    ...     arch="x86_64",
-    ...     ext="",
-    ...     cargo_binstall_archive=True,
-    ... )
-    >>> request.package_name
-    'dear-diary'
-    """
-
-    project_root: Path
-    package_name: str
-    version: str
-    target: str
-    os_name: str
-    arch: str
-    ext: str
-    cargo_binstall_archive: bool
-
-
-def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
-    """Return the package version, resolving workspace inheritance.
-
-    The installable crate inherits its version from the virtual workspace, so
-    release validation has to understand `version.workspace = true`.
-
-    Parameters
-    ----------
-    project_root : pathlib.Path
-        Repository root containing the workspace `Cargo.toml`.
-    cargo_toml_path : pathlib.Path
-        Manifest path for the installable package, relative to `project_root`.
-
-    Returns
-    -------
-    str
-        Resolved non-empty package version.
-
-    Raises
-    ------
-    FileNotFoundError
-        If either manifest cannot be read.
-    tomllib.TOMLDecodeError
-        If either manifest is not valid TOML.
-    ValueError
-        If the package version is missing, malformed, or cannot be resolved
-        from the workspace package table.
-
-    Examples
-    --------
-    >>> from pathlib import Path
-    >>> load_package_version(Path("."), Path("crates/dear-diary/Cargo.toml"))
-    '0.1.0'
-    """
-    root_manifest = tomllib.loads(
-        (project_root / "Cargo.toml").read_text(encoding="utf-8")
-    )
-    package_manifest = tomllib.loads(
-        (project_root / cargo_toml_path).read_text(encoding="utf-8")
-    )
-    package = package_manifest.get("package")
-    workspace_package = root_manifest.get("workspace", {}).get("package")
-    version = package.get("version") if isinstance(package, dict) else None
-    if isinstance(version, dict) and version.get("workspace") is True:
-        version = (
-            workspace_package.get("version")
-            if isinstance(workspace_package, dict)
-            else None
-        )
-    if not isinstance(version, str) or not version:
-        raise ValueError("invalid or missing package version in manifests")
-    return version
-
-
-def assert_tag_matches_version(tag_name: str, cargo_version: str) -> None:
-    """Validate that a release tag matches the Cargo package version.
-
-    Parameters
-    ----------
-    tag_name : str
-        GitHub tag name, with or without a leading `v`.
-    cargo_version : str
-        Version resolved from Cargo manifests.
-
-    Returns
-    -------
-    None
-        The function returns only when the versions match.
-
-    Raises
-    ------
-    ValueError
-        If the tag version and Cargo version differ.
-
-    Examples
-    --------
-    >>> assert_tag_matches_version("v0.1.0", "0.1.0")
-    >>> assert_tag_matches_version("0.1.0", "0.1.0")
-    """
-    tag_version = tag_name.removeprefix("v")
-    if tag_version != cargo_version:
-        msg = (
-            f"Tag version {tag_version} does not match Cargo.toml version "
-            f"{cargo_version}"
-        )
-        raise ValueError(msg)
-
-
-def write_sha256_manifest(path: Path) -> Path:
-    """Write a SHA-256 manifest containing only the artefact basename.
-
-    Parameters
-    ----------
-    path : pathlib.Path
-        Artefact file to hash.
-
-    Returns
-    -------
-    pathlib.Path
-        Path to the `.sha256` manifest written next to `path`.
-
-    Raises
-    ------
-    FileNotFoundError
-        If `path` does not exist.
-    OSError
-        If the artefact cannot be read or the manifest cannot be written.
-
-    Notes
-    -----
-    This function writes a sibling file as a side effect. The manifest uses the
-    artefact basename so users can run `sha256sum -c` from the download
-    directory.
-
-    Examples
-    --------
-    >>> from pathlib import Path
-    >>> path = Path("artifacts/linux-x86_64/dear-diary-linux-x86_64")
-    >>> manifest = write_sha256_manifest(path)
-    >>> manifest.name
-    'dear-diary-linux-x86_64.sha256'
-    """
-    digest = hashlib.sha256(path.read_bytes()).hexdigest()
-    manifest_path = path.with_name(f"{path.name}.sha256")
-    manifest_path.write_text(f"{digest}  {path.name}\n", encoding="utf-8")
-    return manifest_path
-
-
-def prepare_artifacts(request: ArtifactRequest) -> list[Path]:
-    """Prepare release binaries, checksums, and optional binstall archives.
-
-    Parameters
-    ----------
-    request : ArtifactRequest
-        Release artefact preparation request.
-
-    Returns
-    -------
-    list[pathlib.Path]
-        Paths to every generated artefact and checksum manifest.
-
-    Raises
-    ------
-    FileNotFoundError
-        If the release binary for `request.target` is missing.
-    OSError
-        If artefact directories, copied binaries, archives, or checksum
-        manifests cannot be created.
-    tarfile.TarError
-        If the `cargo-binstall` archive cannot be written.
-
-    Notes
-    -----
-    This function creates files under `artifacts/<os>-<arch>` and may
-    overwrite existing artefacts with the same names.
-
-    Examples
-    --------
-    >>> from pathlib import Path
-    >>> request = ArtifactRequest(
-    ...     project_root=Path("."),
-    ...     package_name="dear-diary",
-    ...     version="0.1.0",
-    ...     target="x86_64-unknown-linux-gnu",
-    ...     os_name="linux",
-    ...     arch="x86_64",
-    ...     ext="",
-    ...     cargo_binstall_archive=True,
-    ... )
-    >>> outputs = prepare_artifacts(request)  # doctest: +SKIP
-    >>> len(outputs)  # doctest: +SKIP
-    4
-    """
-    artifact_dir = request.project_root / "artifacts" / (
-        f"{request.os_name}-{request.arch}"
-    )
-    binary_path = (
-        request.project_root
-        / "target"
-        / request.target
-        / "release"
-        / f"{request.package_name}{request.ext}"
-    )
-    binary_name = f"{request.package_name}-{request.os_name}-{request.arch}{request.ext}"
-
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    copied_binary = artifact_dir / binary_name
-    shutil.copy2(binary_path, copied_binary)
-
-    outputs = [copied_binary, write_sha256_manifest(copied_binary)]
-    if request.cargo_binstall_archive:
-        archive_path = artifact_dir / (
-            f"{request.package_name}-{request.version}-{request.target}.tar.gz"
-        )
-        with tarfile.open(archive_path, "w:gz") as archive:
-            archive.add(binary_path, arcname=f"{request.package_name}{request.ext}")
-        outputs.extend([archive_path, write_sha256_manifest(archive_path)])
-    return outputs
 
 
 @app.command
@@ -426,10 +155,11 @@ def prepare_artifact(
     ...     cargo_binstall_archive=True,
     ... )  # doctest: +SKIP
     """
+    root = project_root.resolve()
     release_version = version.removeprefix("v")
     outputs = prepare_artifacts(
         ArtifactRequest(
-            project_root=project_root.resolve(),
+            project_root=root,
             package_name=package_name,
             version=release_version,
             target=target,
@@ -441,7 +171,7 @@ def prepare_artifact(
     )
     print(f"Prepared {len(outputs)} release artefacts:")
     for output in outputs:
-        print(f"- {output.relative_to(project_root.resolve())}")
+        print(f"- {output.relative_to(root)}")
 
 
 if __name__ == "__main__":

--- a/scripts/release_support.py
+++ b/scripts/release_support.py
@@ -29,6 +29,7 @@ Prepare one release artefact set::
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Annotated
 
@@ -37,6 +38,9 @@ from cyclopts import App, Parameter
 
 from release_packaging import ArtifactRequest, prepare_artifacts
 from release_version import assert_tag_matches_version, load_package_version
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("release_support")
 
 app = App(config=cyclopts.config.Env("INPUT_", command=False))
 
@@ -86,8 +90,28 @@ def verify_version(
     ... )  # doctest: +SKIP
     """
     root = project_root.resolve()
-    cargo_version = load_package_version(root, cargo_toml_path)
-    assert_tag_matches_version(github_ref_name, cargo_version)
+    logger.info(
+        "operation=verify_version phase=start project_root=%s cargo_toml_path=%s tag=%s",
+        root,
+        cargo_toml_path,
+        github_ref_name,
+    )
+    try:
+        cargo_version = load_package_version(root, cargo_toml_path)
+        assert_tag_matches_version(github_ref_name, cargo_version)
+    except Exception:
+        logger.exception(
+            "operation=verify_version phase=failed project_root=%s cargo_toml_path=%s tag=%s",
+            root,
+            cargo_toml_path,
+            github_ref_name,
+        )
+        raise
+    logger.info(
+        "operation=verify_version phase=complete tag=%s cargo_version=%s",
+        github_ref_name,
+        cargo_version,
+    )
     print(f"Release tag {github_ref_name.removeprefix('v')} matches Cargo.toml.")
 
 
@@ -157,17 +181,50 @@ def prepare_artifact(
     """
     root = project_root.resolve()
     release_version = version.removeprefix("v")
-    outputs = prepare_artifacts(
-        ArtifactRequest(
-            project_root=root,
-            package_name=package_name,
-            version=release_version,
-            target=target,
-            os_name=os_name,
-            arch=arch,
-            ext=ext,
-            cargo_binstall_archive=cargo_binstall_archive,
+    logger.info(
+        (
+            "operation=prepare_artifact phase=start project_root=%s package=%s "
+            "version=%s target=%s os=%s arch=%s binstall=%s"
+        ),
+        root,
+        package_name,
+        release_version,
+        target,
+        os_name,
+        arch,
+        cargo_binstall_archive,
+    )
+    try:
+        outputs = prepare_artifacts(
+            ArtifactRequest(
+                project_root=root,
+                package_name=package_name,
+                version=release_version,
+                target=target,
+                os_name=os_name,
+                arch=arch,
+                ext=ext,
+                cargo_binstall_archive=cargo_binstall_archive,
+            )
         )
+    except Exception:
+        logger.exception(
+            (
+                "operation=prepare_artifact phase=failed project_root=%s package=%s "
+                "version=%s target=%s os=%s arch=%s binstall=%s"
+            ),
+            root,
+            package_name,
+            release_version,
+            target,
+            os_name,
+            arch,
+            cargo_binstall_archive,
+        )
+        raise
+    logger.info(
+        "operation=prepare_artifact phase=complete metric=release_artifacts_prepared count=%d",
+        len(outputs),
     )
     print(f"Prepared {len(outputs)} release artefacts:")
     for output in outputs:

--- a/scripts/release_support.py
+++ b/scripts/release_support.py
@@ -3,7 +3,31 @@
 # requires-python = ">=3.13"
 # dependencies = ["cyclopts>=2.9"]
 # ///
-"""Release workflow helpers for Dear Diary binary artefacts."""
+"""Release workflow helpers for Dear Diary binary artefacts.
+
+This module contains the testable parts of the GitHub release workflow:
+Cargo manifest version resolution, tag validation, release binary copying,
+`cargo-binstall` archive creation, and SHA-256 manifest generation. The
+workflow calls the Cyclopts commands directly through `uv`, while tests import
+the pure helper functions.
+
+Typical usage is from GitHub Actions with `INPUT_*` environment variables.
+
+Examples
+--------
+Verify that a tag matches the installable crate version::
+
+    INPUT_CARGO_TOML_PATH=crates/dear-diary/Cargo.toml \\
+    INPUT_GITHUB_REF_NAME=v0.1.0 \\
+    uv run scripts/release_support.py verify-version
+
+Prepare one Linux release artefact set::
+
+    INPUT_PACKAGE_NAME=dear-diary INPUT_VERSION=v0.1.0 \\
+    INPUT_TARGET=x86_64-unknown-linux-gnu INPUT_OS=linux \\
+    INPUT_ARCH=x86_64 INPUT_CARGO_BINSTALL_ARCHIVE=true \\
+    uv run scripts/release_support.py prepare-artifact
+"""
 
 from __future__ import annotations
 
@@ -24,7 +48,59 @@ app = App(config=cyclopts.config.Env("INPUT_", command=False))
 
 @dataclass(frozen=True)
 class ArtifactRequest:
-    """Configuration required to prepare one release artefact set."""
+    """Configuration required to prepare one release artefact set.
+
+    Parameters
+    ----------
+    project_root : pathlib.Path
+        Repository root containing `target/` and receiving `artifacts/`.
+    package_name : str
+        Cargo package and binary name, for example `dear-diary`.
+    version : str
+        Release version without the leading `v`.
+    target : str
+        Rust target triple used for the release build.
+    os_name : str
+        Operating system label used in the uploaded binary name.
+    arch : str
+        Architecture label used in the uploaded binary name.
+    ext : str
+        Platform executable suffix, such as `.exe` on Windows or an empty
+        string on Unix targets.
+    cargo_binstall_archive : bool
+        Whether to create a `cargo-binstall` tarball alongside the binary.
+
+    Returns
+    -------
+    ArtifactRequest
+        Immutable request object consumed by :func:`prepare_artifacts`.
+
+    Raises
+    ------
+    None
+        Dataclass construction performs no filesystem validation.
+
+    Notes
+    -----
+    `prepare_artifacts` performs the filesystem side effects described by this
+    request.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> request = ArtifactRequest(
+    ...     project_root=Path("."),
+    ...     package_name="dear-diary",
+    ...     version="0.1.0",
+    ...     target="x86_64-unknown-linux-gnu",
+    ...     os_name="linux",
+    ...     arch="x86_64",
+    ...     ext="",
+    ...     cargo_binstall_archive=True,
+    ... )
+    >>> request.package_name
+    'dear-diary'
+    """
 
     project_root: Path
     package_name: str
@@ -41,6 +117,34 @@ def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
 
     The installable crate inherits its version from the virtual workspace, so
     release validation has to understand `version.workspace = true`.
+
+    Parameters
+    ----------
+    project_root : pathlib.Path
+        Repository root containing the workspace `Cargo.toml`.
+    cargo_toml_path : pathlib.Path
+        Manifest path for the installable package, relative to `project_root`.
+
+    Returns
+    -------
+    str
+        Resolved non-empty package version.
+
+    Raises
+    ------
+    FileNotFoundError
+        If either manifest cannot be read.
+    tomllib.TOMLDecodeError
+        If either manifest is not valid TOML.
+    ValueError
+        If the package version is missing, malformed, or cannot be resolved
+        from the workspace package table.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> load_package_version(Path("."), Path("crates/dear-diary/Cargo.toml"))
+    '0.1.0'
     """
     root_manifest = tomllib.loads(
         (project_root / "Cargo.toml").read_text(encoding="utf-8")
@@ -48,20 +152,45 @@ def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
     package_manifest = tomllib.loads(
         (project_root / cargo_toml_path).read_text(encoding="utf-8")
     )
-    version = package_manifest["package"].get("version")
-    if isinstance(version, dict) and version.get("workspace"):
-        version = root_manifest["workspace"]["package"]["version"]
-    if not isinstance(version, str) or not version:
-        msg = (
-            f"Could not read package.version from {cargo_toml_path} or "
-            "workspace.package.version from Cargo.toml."
+    package = package_manifest.get("package")
+    workspace_package = root_manifest.get("workspace", {}).get("package")
+    version = package.get("version") if isinstance(package, dict) else None
+    if isinstance(version, dict) and version.get("workspace") is True:
+        version = (
+            workspace_package.get("version")
+            if isinstance(workspace_package, dict)
+            else None
         )
-        raise ValueError(msg)
+    if not isinstance(version, str) or not version:
+        raise ValueError("invalid or missing package version in manifests")
     return version
 
 
 def assert_tag_matches_version(tag_name: str, cargo_version: str) -> None:
-    """Validate that a release tag matches the Cargo package version."""
+    """Validate that a release tag matches the Cargo package version.
+
+    Parameters
+    ----------
+    tag_name : str
+        GitHub tag name, with or without a leading `v`.
+    cargo_version : str
+        Version resolved from Cargo manifests.
+
+    Returns
+    -------
+    None
+        The function returns only when the versions match.
+
+    Raises
+    ------
+    ValueError
+        If the tag version and Cargo version differ.
+
+    Examples
+    --------
+    >>> assert_tag_matches_version("v0.1.0", "0.1.0")
+    >>> assert_tag_matches_version("0.1.0", "0.1.0")
+    """
     tag_version = tag_name.removeprefix("v")
     if tag_version != cargo_version:
         msg = (
@@ -72,7 +201,39 @@ def assert_tag_matches_version(tag_name: str, cargo_version: str) -> None:
 
 
 def write_sha256_manifest(path: Path) -> Path:
-    """Write a SHA-256 manifest containing only the artefact basename."""
+    """Write a SHA-256 manifest containing only the artefact basename.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Artefact file to hash.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the `.sha256` manifest written next to `path`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If `path` does not exist.
+    OSError
+        If the artefact cannot be read or the manifest cannot be written.
+
+    Notes
+    -----
+    This function writes a sibling file as a side effect. The manifest uses the
+    artefact basename so users can run `sha256sum -c` from the download
+    directory.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> path = Path("artifacts/linux-x86_64/dear-diary-linux-x86_64")
+    >>> manifest = write_sha256_manifest(path)
+    >>> manifest.name
+    'dear-diary-linux-x86_64.sha256'
+    """
     digest = hashlib.sha256(path.read_bytes()).hexdigest()
     manifest_path = path.with_name(f"{path.name}.sha256")
     manifest_path.write_text(f"{digest}  {path.name}\n", encoding="utf-8")
@@ -80,7 +241,50 @@ def write_sha256_manifest(path: Path) -> Path:
 
 
 def prepare_artifacts(request: ArtifactRequest) -> list[Path]:
-    """Prepare release binaries, checksums, and optional binstall archives."""
+    """Prepare release binaries, checksums, and optional binstall archives.
+
+    Parameters
+    ----------
+    request : ArtifactRequest
+        Release artefact preparation request.
+
+    Returns
+    -------
+    list[pathlib.Path]
+        Paths to every generated artefact and checksum manifest.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the release binary for `request.target` is missing.
+    OSError
+        If artefact directories, copied binaries, archives, or checksum
+        manifests cannot be created.
+    tarfile.TarError
+        If the `cargo-binstall` archive cannot be written.
+
+    Notes
+    -----
+    This function creates files under `artifacts/<os>-<arch>` and may
+    overwrite existing artefacts with the same names.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> request = ArtifactRequest(
+    ...     project_root=Path("."),
+    ...     package_name="dear-diary",
+    ...     version="0.1.0",
+    ...     target="x86_64-unknown-linux-gnu",
+    ...     os_name="linux",
+    ...     arch="x86_64",
+    ...     ext="",
+    ...     cargo_binstall_archive=True,
+    ... )
+    >>> outputs = prepare_artifacts(request)  # doctest: +SKIP
+    >>> len(outputs)  # doctest: +SKIP
+    4
+    """
     artifact_dir = request.project_root / "artifacts" / (
         f"{request.os_name}-{request.arch}"
     )
@@ -115,7 +319,43 @@ def verify_version(
     github_ref_name: Annotated[str, Parameter(required=True)],
     project_root: Path = Path("."),
 ) -> None:
-    """Verify that the release tag matches the Cargo package version."""
+    """Verify that the release tag matches the Cargo package version.
+
+    Parameters
+    ----------
+    cargo_toml_path : pathlib.Path
+        Manifest path for the installable package, relative to `project_root`.
+    github_ref_name : str
+        GitHub reference name for the release tag.
+    project_root : pathlib.Path, optional
+        Repository root. Defaults to the current working directory.
+
+    Returns
+    -------
+    None
+        Prints a success message when the tag matches.
+
+    Raises
+    ------
+    FileNotFoundError
+        If a required Cargo manifest cannot be read.
+    tomllib.TOMLDecodeError
+        If a Cargo manifest is invalid TOML.
+    ValueError
+        If the manifest version is invalid or the tag does not match it.
+
+    Notes
+    -----
+    This command writes to standard output and is used by the GitHub release
+    workflow before any build artefacts are published.
+
+    Examples
+    --------
+    >>> verify_version(
+    ...     cargo_toml_path=Path("crates/dear-diary/Cargo.toml"),
+    ...     github_ref_name="v0.1.0",
+    ... )  # doctest: +SKIP
+    """
     root = project_root.resolve()
     cargo_version = load_package_version(root, cargo_toml_path)
     assert_tag_matches_version(github_ref_name, cargo_version)
@@ -134,7 +374,58 @@ def prepare_artifact(
     cargo_binstall_archive: bool = False,
     project_root: Path = Path("."),
 ) -> None:
-    """Prepare one release artefact set for the workflow matrix entry."""
+    """Prepare one release artefact set for the workflow matrix entry.
+
+    Parameters
+    ----------
+    package_name : str
+        Cargo package and binary name.
+    version : str
+        GitHub release tag or version. A leading `v` is stripped before archive
+        names are composed.
+    target : str
+        Rust target triple for the compiled binary.
+    os_name : str
+        Operating system label used in the uploaded binary name.
+    arch : str
+        Architecture label used in the uploaded binary name.
+    ext : str, optional
+        Platform executable suffix. Defaults to an empty string.
+    cargo_binstall_archive : bool, optional
+        Whether to create a `cargo-binstall` archive. Defaults to `False`.
+    project_root : pathlib.Path, optional
+        Repository root. Defaults to the current working directory.
+
+    Returns
+    -------
+    None
+        Prints generated artefact paths for workflow diagnostics.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the expected release binary is missing.
+    OSError
+        If artefact output files cannot be created.
+    tarfile.TarError
+        If archive creation fails.
+
+    Notes
+    -----
+    This command writes release artefacts under `artifacts/<os>-<arch>` and is
+    intentionally idempotent for reruns that prepare the same matrix target.
+
+    Examples
+    --------
+    >>> prepare_artifact(
+    ...     package_name="dear-diary",
+    ...     version="v0.1.0",
+    ...     target="x86_64-unknown-linux-gnu",
+    ...     os_name="linux",
+    ...     arch="x86_64",
+    ...     cargo_binstall_archive=True,
+    ... )  # doctest: +SKIP
+    """
     release_version = version.removeprefix("v")
     outputs = prepare_artifacts(
         ArtifactRequest(

--- a/scripts/release_support.py
+++ b/scripts/release_support.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["cyclopts>=2.9"]
+# ///
+"""Release workflow helpers for Dear Diary binary artefacts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tarfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+from cyclopts import App, Parameter
+
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+
+@dataclass(frozen=True)
+class ArtifactRequest:
+    """Configuration required to prepare one release artefact set."""
+
+    project_root: Path
+    package_name: str
+    version: str
+    target: str
+    os_name: str
+    arch: str
+    ext: str
+    cargo_binstall_archive: bool
+
+
+def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
+    """Return the package version, resolving workspace inheritance.
+
+    The installable crate inherits its version from the virtual workspace, so
+    release validation has to understand `version.workspace = true`.
+    """
+    root_manifest = tomllib.loads(
+        (project_root / "Cargo.toml").read_text(encoding="utf-8")
+    )
+    package_manifest = tomllib.loads(
+        (project_root / cargo_toml_path).read_text(encoding="utf-8")
+    )
+    version = package_manifest["package"].get("version")
+    if isinstance(version, dict) and version.get("workspace"):
+        version = root_manifest["workspace"]["package"]["version"]
+    if not isinstance(version, str) or not version:
+        msg = (
+            f"Could not read package.version from {cargo_toml_path} or "
+            "workspace.package.version from Cargo.toml."
+        )
+        raise ValueError(msg)
+    return version
+
+
+def assert_tag_matches_version(tag_name: str, cargo_version: str) -> None:
+    """Validate that a release tag matches the Cargo package version."""
+    tag_version = tag_name.removeprefix("v")
+    if tag_version != cargo_version:
+        msg = (
+            f"Tag version {tag_version} does not match Cargo.toml version "
+            f"{cargo_version}"
+        )
+        raise ValueError(msg)
+
+
+def write_sha256_manifest(path: Path) -> Path:
+    """Write a SHA-256 manifest containing only the artefact basename."""
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    manifest_path = path.with_name(f"{path.name}.sha256")
+    manifest_path.write_text(f"{digest}  {path.name}\n", encoding="utf-8")
+    return manifest_path
+
+
+def prepare_artifacts(request: ArtifactRequest) -> list[Path]:
+    """Prepare release binaries, checksums, and optional binstall archives."""
+    artifact_dir = request.project_root / "artifacts" / (
+        f"{request.os_name}-{request.arch}"
+    )
+    binary_path = (
+        request.project_root
+        / "target"
+        / request.target
+        / "release"
+        / f"{request.package_name}{request.ext}"
+    )
+    binary_name = f"{request.package_name}-{request.os_name}-{request.arch}{request.ext}"
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    copied_binary = artifact_dir / binary_name
+    shutil.copy2(binary_path, copied_binary)
+
+    outputs = [copied_binary, write_sha256_manifest(copied_binary)]
+    if request.cargo_binstall_archive:
+        archive_path = artifact_dir / (
+            f"{request.package_name}-{request.version}-{request.target}.tar.gz"
+        )
+        with tarfile.open(archive_path, "w:gz") as archive:
+            archive.add(binary_path, arcname=f"{request.package_name}{request.ext}")
+        outputs.extend([archive_path, write_sha256_manifest(archive_path)])
+    return outputs
+
+
+@app.command
+def verify_version(
+    *,
+    cargo_toml_path: Annotated[Path, Parameter(required=True)],
+    github_ref_name: Annotated[str, Parameter(required=True)],
+    project_root: Path = Path("."),
+) -> None:
+    """Verify that the release tag matches the Cargo package version."""
+    root = project_root.resolve()
+    cargo_version = load_package_version(root, cargo_toml_path)
+    assert_tag_matches_version(github_ref_name, cargo_version)
+    print(f"Release tag {github_ref_name.removeprefix('v')} matches Cargo.toml.")
+
+
+@app.command
+def prepare_artifact(
+    *,
+    package_name: Annotated[str, Parameter(required=True)],
+    version: Annotated[str, Parameter(required=True)],
+    target: Annotated[str, Parameter(required=True)],
+    os_name: Annotated[str, Parameter(required=True, env_var="INPUT_OS")],
+    arch: Annotated[str, Parameter(required=True)],
+    ext: str = "",
+    cargo_binstall_archive: bool = False,
+    project_root: Path = Path("."),
+) -> None:
+    """Prepare one release artefact set for the workflow matrix entry."""
+    release_version = version.removeprefix("v")
+    outputs = prepare_artifacts(
+        ArtifactRequest(
+            project_root=project_root.resolve(),
+            package_name=package_name,
+            version=release_version,
+            target=target,
+            os_name=os_name,
+            arch=arch,
+            ext=ext,
+            cargo_binstall_archive=cargo_binstall_archive,
+        )
+    )
+    print(f"Prepared {len(outputs)} release artefacts:")
+    for output in outputs:
+        print(f"- {output.relative_to(project_root.resolve())}")
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -18,8 +18,11 @@ Validate a tag before publishing::
 
 from __future__ import annotations
 
+import logging
 import tomllib
 from pathlib import Path
+
+logger = logging.getLogger("release_support.version")
 
 
 def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
@@ -56,6 +59,11 @@ def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
     >>> load_package_version(Path("."), Path("crates/dear-diary/Cargo.toml"))
     '0.1.0'
     """
+    logger.info(
+        "operation=load_package_version phase=start project_root=%s cargo_toml_path=%s",
+        project_root,
+        cargo_toml_path,
+    )
     root_manifest = tomllib.loads(
         (project_root / "Cargo.toml").read_text(encoding="utf-8")
     )
@@ -72,7 +80,16 @@ def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
             else None
         )
     if not isinstance(version, str) or not version:
+        logger.error(
+            "operation=load_package_version phase=invalid project_root=%s cargo_toml_path=%s",
+            project_root,
+            cargo_toml_path,
+        )
         raise ValueError("invalid or missing package version in manifests")
+    logger.info(
+        "operation=load_package_version phase=complete cargo_version=%s",
+        version,
+    )
     return version
 
 
@@ -101,10 +118,24 @@ def assert_tag_matches_version(tag_name: str, cargo_version: str) -> None:
     >>> assert_tag_matches_version("v0.1.0", "0.1.0")
     >>> assert_tag_matches_version("0.1.0", "0.1.0")
     """
+    logger.info(
+        "operation=assert_tag_matches_version phase=start tag=%s cargo_version=%s",
+        tag_name,
+        cargo_version,
+    )
     tag_version = tag_name.removeprefix("v")
     if tag_version != cargo_version:
         msg = (
             f"Tag version {tag_version} does not match Cargo.toml version "
             f"{cargo_version}"
         )
+        logger.error(
+            "operation=assert_tag_matches_version phase=mismatch tag_version=%s cargo_version=%s",
+            tag_version,
+            cargo_version,
+        )
         raise ValueError(msg)
+    logger.info(
+        "operation=assert_tag_matches_version phase=complete tag_version=%s",
+        tag_version,
+    )

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -1,0 +1,110 @@
+"""Cargo manifest version helpers for release validation.
+
+This module resolves the installable package version from Cargo manifests and
+validates that GitHub release tags match it. It deliberately contains no
+GitHub Actions or packaging code, so manifest parsing can be tested directly.
+
+Examples
+--------
+Resolve the current package version::
+
+    from pathlib import Path
+    version = load_package_version(Path("."), Path("crates/dear-diary/Cargo.toml"))
+
+Validate a tag before publishing::
+
+    assert_tag_matches_version("v0.1.0", version)
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def load_package_version(project_root: Path, cargo_toml_path: Path) -> str:
+    """Return the package version, resolving workspace inheritance.
+
+    The installable crate inherits its version from the virtual workspace, so
+    release validation has to understand `version.workspace = true`.
+
+    Parameters
+    ----------
+    project_root : pathlib.Path
+        Repository root containing the workspace `Cargo.toml`.
+    cargo_toml_path : pathlib.Path
+        Manifest path for the installable package, relative to `project_root`.
+
+    Returns
+    -------
+    str
+        Resolved non-empty package version.
+
+    Raises
+    ------
+    FileNotFoundError
+        If either manifest cannot be read.
+    tomllib.TOMLDecodeError
+        If either manifest is not valid TOML.
+    ValueError
+        If the package version is missing, malformed, or cannot be resolved
+        from the workspace package table.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> load_package_version(Path("."), Path("crates/dear-diary/Cargo.toml"))
+    '0.1.0'
+    """
+    root_manifest = tomllib.loads(
+        (project_root / "Cargo.toml").read_text(encoding="utf-8")
+    )
+    package_manifest = tomllib.loads(
+        (project_root / cargo_toml_path).read_text(encoding="utf-8")
+    )
+    package = package_manifest.get("package")
+    workspace_package = root_manifest.get("workspace", {}).get("package")
+    version = package.get("version") if isinstance(package, dict) else None
+    if isinstance(version, dict) and version.get("workspace") is True:
+        version = (
+            workspace_package.get("version")
+            if isinstance(workspace_package, dict)
+            else None
+        )
+    if not isinstance(version, str) or not version:
+        raise ValueError("invalid or missing package version in manifests")
+    return version
+
+
+def assert_tag_matches_version(tag_name: str, cargo_version: str) -> None:
+    """Validate that a release tag matches the Cargo package version.
+
+    Parameters
+    ----------
+    tag_name : str
+        GitHub tag name, with or without a leading `v`.
+    cargo_version : str
+        Version resolved from Cargo manifests.
+
+    Returns
+    -------
+    None
+        The function returns only when the versions match.
+
+    Raises
+    ------
+    ValueError
+        If the tag version and Cargo version differ.
+
+    Examples
+    --------
+    >>> assert_tag_matches_version("v0.1.0", "0.1.0")
+    >>> assert_tag_matches_version("0.1.0", "0.1.0")
+    """
+    tag_version = tag_name.removeprefix("v")
+    if tag_version != cargo_version:
+        msg = (
+            f"Tag version {tag_version} does not match Cargo.toml version "
+            f"{cargo_version}"
+        )
+        raise ValueError(msg)

--- a/scripts/tests/__snapshots__/test_release_support.ambr
+++ b/scripts/tests/__snapshots__/test_release_support.ambr
@@ -1,0 +1,17 @@
+# serializer version: 1
+# name: test_prepare_artifact_command_output_snapshot
+  '''
+  Prepared 4 release artefacts:
+  - artifacts/linux-x86_64/dear-diary-linux-x86_64
+  - artifacts/linux-x86_64/dear-diary-linux-x86_64.sha256
+  - artifacts/linux-x86_64/dear-diary-0.1.0-x86_64-unknown-linux-gnu.tar.gz
+  - artifacts/linux-x86_64/dear-diary-0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256
+  
+  '''
+# ---
+# name: test_verify_version_command_output_snapshot
+  '''
+  Release tag 0.1.0 matches Cargo.toml.
+  
+  '''
+# ---

--- a/scripts/tests/test_release_support.py
+++ b/scripts/tests/test_release_support.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import sys
 import tarfile
 import tomllib
 from pathlib import Path
 
 import pytest
 
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import release_support
 from scripts.release_packaging import (
     ArtifactRequest,
     prepare_artifacts,
@@ -44,6 +50,7 @@ version.workspace = true
 
 
 def test_load_package_version_resolves_workspace_version(tmp_path: Path) -> None:
+    """Resolve a workspace-inherited package version from test manifests."""
     cargo_toml_path = write_manifest_pair(tmp_path)
 
     version = load_package_version(tmp_path, cargo_toml_path)
@@ -54,6 +61,7 @@ def test_load_package_version_resolves_workspace_version(tmp_path: Path) -> None
 def test_load_package_version_reports_consistent_manifest_error(
     tmp_path: Path,
 ) -> None:
+    """Report one consistent error when workspace version lookup fails."""
     (tmp_path / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
     crate_dir = tmp_path / "crates" / "dear-diary"
     crate_dir.mkdir(parents=True)
@@ -72,6 +80,7 @@ version.workspace = true
 
 
 def test_dear_diary_manifest_defines_binstall_metadata() -> None:
+    """Parse the installable crate manifest and assert binstall metadata."""
     manifest = (PROJECT_ROOT / "crates" / "dear-diary" / "Cargo.toml").read_text(
         encoding="utf-8"
     )
@@ -91,15 +100,18 @@ def test_dear_diary_manifest_defines_binstall_metadata() -> None:
 
 
 def test_assert_tag_matches_version_accepts_prefixed_tag() -> None:
+    """Accept GitHub release tags whose version matches Cargo metadata."""
     assert_tag_matches_version("v0.1.0", "0.1.0")
 
 
 def test_assert_tag_matches_version_rejects_mismatch() -> None:
+    """Reject GitHub release tags whose version differs from Cargo metadata."""
     with pytest.raises(ValueError, match="does not match"):
         assert_tag_matches_version("v0.2.0", "0.1.0")
 
 
 def test_write_sha256_manifest_uses_asset_basename(tmp_path: Path) -> None:
+    """Write checksum manifests that contain only the asset basename."""
     asset = tmp_path / "artifacts" / "linux-x86_64" / "dear-diary-linux-x86_64"
     asset.parent.mkdir(parents=True)
     asset.write_bytes(b"release binary")
@@ -114,6 +126,7 @@ def test_write_sha256_manifest_uses_asset_basename(tmp_path: Path) -> None:
 def test_prepare_artifacts_creates_binstall_archive_with_binary_at_root(
     tmp_path: Path,
 ) -> None:
+    """Create binstall archives with the binary at the archive root."""
     binary_path = (
         tmp_path
         / "target"
@@ -156,3 +169,122 @@ def test_prepare_artifacts_creates_binstall_archive_with_binary_at_root(
     assert checksum.endswith(
         "  dear-diary-0.1.0-x86_64-unknown-linux-gnu.tar.gz\n"
     )
+
+
+def test_prepare_artifacts_skips_binstall_archive_when_disabled(
+    tmp_path: Path,
+) -> None:
+    """Create only binary and checksum outputs when binstall is disabled."""
+    binary_path = (
+        tmp_path
+        / "target"
+        / "x86_64-unknown-freebsd"
+        / "release"
+        / "dear-diary"
+    )
+    binary_path.parent.mkdir(parents=True)
+    binary_path.write_bytes(b"release binary")
+
+    outputs = prepare_artifacts(
+        ArtifactRequest(
+            project_root=tmp_path,
+            package_name="dear-diary",
+            version="0.1.0",
+            target="x86_64-unknown-freebsd",
+            os_name="freebsd",
+            arch="x86_64",
+            ext="",
+            cargo_binstall_archive=False,
+        )
+    )
+
+    output_names = {path.name for path in outputs}
+    assert output_names == {
+        "dear-diary-freebsd-x86_64",
+        "dear-diary-freebsd-x86_64.sha256",
+    }
+
+
+def test_prepare_artifacts_reports_missing_binary(tmp_path: Path) -> None:
+    """Raise a file-not-found error when the expected binary is absent."""
+    request = ArtifactRequest(
+        project_root=tmp_path,
+        package_name="dear-diary",
+        version="0.1.0",
+        target="x86_64-unknown-linux-gnu",
+        os_name="linux",
+        arch="x86_64",
+        ext="",
+        cargo_binstall_archive=True,
+    )
+
+    with pytest.raises(FileNotFoundError):
+        prepare_artifacts(request)
+
+
+def test_verify_version_command_prints_success(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Exercise the verify-version Cyclopts command body."""
+    cargo_toml_path = write_manifest_pair(tmp_path)
+
+    release_support.verify_version(
+        cargo_toml_path=cargo_toml_path,
+        github_ref_name="v0.1.0",
+        project_root=tmp_path,
+    )
+
+    assert "Release tag 0.1.0 matches Cargo.toml." in capsys.readouterr().out
+
+
+def test_prepare_artifact_command_prints_outputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Exercise the prepare-artifact Cyclopts command body."""
+    binary_path = (
+        tmp_path
+        / "target"
+        / "x86_64-unknown-linux-gnu"
+        / "release"
+        / "dear-diary"
+    )
+    binary_path.parent.mkdir(parents=True)
+    binary_path.write_bytes(b"release binary")
+
+    release_support.prepare_artifact(
+        package_name="dear-diary",
+        version="v0.1.0",
+        target="x86_64-unknown-linux-gnu",
+        os_name="linux",
+        arch="x86_64",
+        cargo_binstall_archive=True,
+        project_root=tmp_path,
+    )
+
+    output = capsys.readouterr().out
+    assert "Prepared 4 release artefacts:" in output
+    assert "dear-diary-0.1.0-x86_64-unknown-linux-gnu.tar.gz" in output
+
+
+def test_prepare_artifact_command_logs_missing_binary(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Log command context when artefact preparation fails."""
+    caplog.set_level("INFO")
+
+    with pytest.raises(FileNotFoundError):
+        release_support.prepare_artifact(
+            package_name="dear-diary",
+            version="v0.1.0",
+            target="x86_64-unknown-linux-gnu",
+            os_name="linux",
+            arch="x86_64",
+            cargo_binstall_archive=True,
+            project_root=tmp_path,
+        )
+
+    assert "operation=prepare_artifact phase=failed" in caplog.text
+    assert "target=x86_64-unknown-linux-gnu" in caplog.text

--- a/scripts/tests/test_release_support.py
+++ b/scripts/tests/test_release_support.py
@@ -1,13 +1,24 @@
-"""Tests for release workflow helper behaviour."""
+"""Tests for release workflow helper behaviour.
+
+This module verifies the release automation surfaces used by GitHub Actions:
+`release_support` command wiring, `release_version` manifest and tag checks,
+and `release_packaging` binary, checksum, and `cargo-binstall` artefact
+creation. The tests cover direct helper functions, command-style entry points,
+environment-variable execution through Cyclopts, and workflow upload-script
+contracts so changes to release automation are caught before a tag publish.
+"""
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 import tarfile
 import tomllib
 from pathlib import Path
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 if str(SCRIPTS_DIR) not in sys.path:
@@ -22,6 +33,8 @@ from scripts.release_packaging import (
 from scripts.release_version import assert_tag_matches_version, load_package_version
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_SCRIPT = PROJECT_ROOT / "scripts" / "release_support.py"
+RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
 
 
 def write_manifest_pair(project_root: Path) -> Path:
@@ -102,6 +115,11 @@ def test_dear_diary_manifest_defines_binstall_metadata() -> None:
 def test_assert_tag_matches_version_accepts_prefixed_tag() -> None:
     """Accept GitHub release tags whose version matches Cargo metadata."""
     assert_tag_matches_version("v0.1.0", "0.1.0")
+
+
+def test_assert_tag_matches_version_accepts_plain_tag() -> None:
+    """Accept release tags that omit the conventional leading v."""
+    assert_tag_matches_version("0.1.0", "0.1.0")
 
 
 def test_assert_tag_matches_version_rejects_mismatch() -> None:
@@ -288,3 +306,112 @@ def test_prepare_artifact_command_logs_missing_binary(
 
     assert "operation=prepare_artifact phase=failed" in caplog.text
     assert "target=x86_64-unknown-linux-gnu" in caplog.text
+
+
+def test_prepare_artifacts_supports_aarch64_binstall_target(
+    tmp_path: Path,
+) -> None:
+    """Create the expected archive name for Linux aarch64 releases."""
+    binary_path = (
+        tmp_path
+        / "target"
+        / "aarch64-unknown-linux-gnu"
+        / "release"
+        / "dear-diary"
+    )
+    binary_path.parent.mkdir(parents=True)
+    binary_path.write_bytes(b"release binary")
+
+    outputs = prepare_artifacts(
+        ArtifactRequest(
+            project_root=tmp_path,
+            package_name="dear-diary",
+            version="0.1.0",
+            target="aarch64-unknown-linux-gnu",
+            os_name="linux",
+            arch="aarch64",
+            ext="",
+            cargo_binstall_archive=True,
+        )
+    )
+
+    output_names = {path.name for path in outputs}
+    assert "dear-diary-linux-aarch64" in output_names
+    assert "dear-diary-0.1.0-aarch64-unknown-linux-gnu.tar.gz" in output_names
+
+
+def test_verify_version_command_resolves_environment_variables(
+    tmp_path: Path,
+) -> None:
+    """Exercise Cyclopts environment variable mapping for verify-version."""
+    cargo_toml_path = write_manifest_pair(tmp_path)
+    env = os.environ | {
+        "INPUT_CARGO_TOML_PATH": str(cargo_toml_path),
+        "INPUT_GITHUB_REF_NAME": "v0.1.0",
+    }
+
+    result = subprocess.run(
+        [sys.executable, str(RELEASE_SCRIPT), "verify-version", "--project-root", str(tmp_path)],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert "Release tag 0.1.0 matches Cargo.toml." in result.stdout
+
+
+def test_release_upload_script_uses_bounded_metric_labels() -> None:
+    """Assert GitHub release upload metrics do not include unbounded paths."""
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'echo "Uploading ${file}"' in workflow
+    assert 'gh release upload "${{ github.ref_name }}" "$file" --clobber' in workflow
+    assert 'echo "metric=release_asset_uploaded count=${uploaded_count}"' in workflow
+    assert "metric=release_asset_uploaded count=${uploaded_count} file=" not in workflow
+
+
+def test_verify_version_command_output_snapshot(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the verify-version command output structure."""
+    cargo_toml_path = write_manifest_pair(tmp_path)
+
+    release_support.verify_version(
+        cargo_toml_path=cargo_toml_path,
+        github_ref_name="v0.1.0",
+        project_root=tmp_path,
+    )
+
+    assert capsys.readouterr().out == snapshot
+
+
+def test_prepare_artifact_command_output_snapshot(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the prepare-artifact command output structure."""
+    binary_path = (
+        tmp_path
+        / "target"
+        / "x86_64-unknown-linux-gnu"
+        / "release"
+        / "dear-diary"
+    )
+    binary_path.parent.mkdir(parents=True)
+    binary_path.write_bytes(b"release binary")
+
+    release_support.prepare_artifact(
+        package_name="dear-diary",
+        version="v0.1.0",
+        target="x86_64-unknown-linux-gnu",
+        os_name="linux",
+        arch="x86_64",
+        cargo_binstall_archive=True,
+        project_root=tmp_path,
+    )
+
+    assert capsys.readouterr().out == snapshot

--- a/scripts/tests/test_release_support.py
+++ b/scripts/tests/test_release_support.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import tarfile
+import tomllib
 from pathlib import Path
 
 import pytest
 
-from scripts.release_support import (
+from scripts.release_packaging import (
     ArtifactRequest,
-    assert_tag_matches_version,
-    load_package_version,
     prepare_artifacts,
     write_sha256_manifest,
 )
+from scripts.release_version import assert_tag_matches_version, load_package_version
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -75,11 +75,19 @@ def test_dear_diary_manifest_defines_binstall_metadata() -> None:
     manifest = (PROJECT_ROOT / "crates" / "dear-diary" / "Cargo.toml").read_text(
         encoding="utf-8"
     )
+    parsed_manifest = tomllib.loads(manifest)
+    binstall_metadata = parsed_manifest["package"]["metadata"]["binstall"]
+    linux_overrides = binstall_metadata["overrides"][
+        'cfg(all(target_os = "linux", any(target_arch = "x86_64", '
+        'target_arch = "aarch64"), target_env = "gnu"))'
+    ]
 
-    assert "[package.metadata.binstall]" in manifest
-    assert "{ name }-{ version }-{ target }.tar.gz" in manifest
-    assert 'bin-dir = "{ bin }{ binary-ext }"' in manifest
-    assert 'pkg-fmt = "tgz"' in manifest
+    assert linux_overrides["pkg-url"] == (
+        "{ repo }/releases/download/v{ version }/"
+        "{ name }-{ version }-{ target }.tar.gz"
+    )
+    assert linux_overrides["bin-dir"] == "{ bin }{ binary-ext }"
+    assert linux_overrides["pkg-fmt"] == "tgz"
 
 
 def test_assert_tag_matches_version_accepts_prefixed_tag() -> None:

--- a/scripts/tests/test_release_support.py
+++ b/scripts/tests/test_release_support.py
@@ -51,6 +51,26 @@ def test_load_package_version_resolves_workspace_version(tmp_path: Path) -> None
     assert version == "0.1.0"
 
 
+def test_load_package_version_reports_consistent_manifest_error(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+    crate_dir = tmp_path / "crates" / "dear-diary"
+    crate_dir.mkdir(parents=True)
+    cargo_toml_path = crate_dir / "Cargo.toml"
+    cargo_toml_path.write_text(
+        """
+[package]
+name = "dear-diary"
+version.workspace = true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="invalid or missing package version"):
+        load_package_version(tmp_path, cargo_toml_path.relative_to(tmp_path))
+
+
 def test_dear_diary_manifest_defines_binstall_metadata() -> None:
     manifest = (PROJECT_ROOT / "crates" / "dear-diary" / "Cargo.toml").read_text(
         encoding="utf-8"

--- a/scripts/tests/test_release_support.py
+++ b/scripts/tests/test_release_support.py
@@ -1,0 +1,130 @@
+"""Tests for release workflow helper behaviour."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from scripts.release_support import (
+    ArtifactRequest,
+    assert_tag_matches_version,
+    load_package_version,
+    prepare_artifacts,
+    write_sha256_manifest,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def write_manifest_pair(project_root: Path) -> Path:
+    """Write workspace and package manifests for release version tests."""
+    (project_root / "Cargo.toml").write_text(
+        """
+[workspace]
+
+[workspace.package]
+version = "0.1.0"
+""".strip(),
+        encoding="utf-8",
+    )
+    crate_dir = project_root / "crates" / "dear-diary"
+    crate_dir.mkdir(parents=True)
+    cargo_toml_path = crate_dir / "Cargo.toml"
+    cargo_toml_path.write_text(
+        """
+[package]
+name = "dear-diary"
+version.workspace = true
+""".strip(),
+        encoding="utf-8",
+    )
+    return cargo_toml_path.relative_to(project_root)
+
+
+def test_load_package_version_resolves_workspace_version(tmp_path: Path) -> None:
+    cargo_toml_path = write_manifest_pair(tmp_path)
+
+    version = load_package_version(tmp_path, cargo_toml_path)
+
+    assert version == "0.1.0"
+
+
+def test_dear_diary_manifest_defines_binstall_metadata() -> None:
+    manifest = (PROJECT_ROOT / "crates" / "dear-diary" / "Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "[package.metadata.binstall]" in manifest
+    assert "{ name }-{ version }-{ target }.tar.gz" in manifest
+    assert 'bin-dir = "{ bin }{ binary-ext }"' in manifest
+    assert 'pkg-fmt = "tgz"' in manifest
+
+
+def test_assert_tag_matches_version_accepts_prefixed_tag() -> None:
+    assert_tag_matches_version("v0.1.0", "0.1.0")
+
+
+def test_assert_tag_matches_version_rejects_mismatch() -> None:
+    with pytest.raises(ValueError, match="does not match"):
+        assert_tag_matches_version("v0.2.0", "0.1.0")
+
+
+def test_write_sha256_manifest_uses_asset_basename(tmp_path: Path) -> None:
+    asset = tmp_path / "artifacts" / "linux-x86_64" / "dear-diary-linux-x86_64"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"release binary")
+
+    manifest_path = write_sha256_manifest(asset)
+
+    manifest = manifest_path.read_text(encoding="utf-8")
+    assert manifest.endswith("  dear-diary-linux-x86_64\n")
+    assert "artifacts/" not in manifest
+
+
+def test_prepare_artifacts_creates_binstall_archive_with_binary_at_root(
+    tmp_path: Path,
+) -> None:
+    binary_path = (
+        tmp_path
+        / "target"
+        / "x86_64-unknown-linux-gnu"
+        / "release"
+        / "dear-diary"
+    )
+    binary_path.parent.mkdir(parents=True)
+    binary_path.write_bytes(b"release binary")
+
+    outputs = prepare_artifacts(
+        ArtifactRequest(
+            project_root=tmp_path,
+            package_name="dear-diary",
+            version="0.1.0",
+            target="x86_64-unknown-linux-gnu",
+            os_name="linux",
+            arch="x86_64",
+            ext="",
+            cargo_binstall_archive=True,
+        )
+    )
+
+    output_names = {path.name for path in outputs}
+    assert "dear-diary-linux-x86_64" in output_names
+    assert "dear-diary-0.1.0-x86_64-unknown-linux-gnu.tar.gz" in output_names
+
+    archive_path = (
+        tmp_path
+        / "artifacts"
+        / "linux-x86_64"
+        / "dear-diary-0.1.0-x86_64-unknown-linux-gnu.tar.gz"
+    )
+    with tarfile.open(archive_path, "r:gz") as archive:
+        assert archive.getnames() == ["dear-diary"]
+
+    checksum = archive_path.with_name(f"{archive_path.name}.sha256").read_text(
+        encoding="utf-8"
+    )
+    assert checksum.endswith(
+        "  dear-diary-0.1.0-x86_64-unknown-linux-gnu.tar.gz\n"
+    )


### PR DESCRIPTION
Add `cargo-binstall` package metadata for the installable `dear-diary` binary crate and publish matching Linux GNU archives from the tag-driven release workflow.

Document the release artefact naming contract so the manifest metadata and GitHub release uploads stay aligned.