### PR TITLE
Adopt Cranelift codegen and mold linking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[unstable]
+codegen-backend = true
+
+[profile.dev]
+codegen-backend = "cranelift"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
             **/*.md
             !**/target/**
             !**/dist/**
+      - name: Setup uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+      - name: Script tests
+        run: make test-scripts
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - name: Install mold linker
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes clang mold
       - name: Format
         run: make check-fmt
       - name: Markdown lint
@@ -30,6 +35,8 @@ jobs:
         run: make lint
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        env:
+          CARGO_PROFILE_DEV_CODEGEN_BACKEND: llvm
         with:
           output-path: lcov.info
           format: lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
       - name: Install mold linker
         run: |
           set -euo pipefail
@@ -34,9 +34,7 @@ jobs:
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
-        env:
-          CARGO_PROFILE_DEV_CODEGEN_BACKEND: llvm
+        uses: leynos/shared-actions/.github/actions/generate-coverage@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
         with:
           output-path: lcov.info
           format: lcov
@@ -44,7 +42,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
       - name: Install mold linker
+        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install --yes clang mold
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update \
+            && sudo apt-get install --yes --no-install-recommends clang mold
       - name: Format
         run: make check-fmt
       - name: Markdown lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
           uv run scripts/release_support.py verify-version
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - name: Install mold linker
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes clang mold
       - name: Cache cross binary
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           "${{ steps.setup-python.outputs.python-path }}" --version
           uv run scripts/release_support.py verify-version
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
       - name: Install mold linker
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,12 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54
       - name: Install mold linker
+        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install --yes clang mold
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update \
+            && sudo apt-get install --yes --no-install-recommends clang mold
       - name: Cache cross binary
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ export COLLECTION_NAME="my-memories"
 Connect via MCP stdio transport. The server speaks JSON-RPC 2.0, like all
 well-mannered protocols should.
 
+## Toolchain prerequisites
+
+This workspace uses the pinned Nightly toolchain from `rust-toolchain.toml`.
+Development builds use the Cranelift code generation backend, and Linux
+`x86_64-unknown-linux-gnu` builds link through `clang` with `mold`.
+
+Install the pinned Rust toolchain components with:
+
+```bash
+rustup toolchain install nightly-2025-12-10
+rustup component add rustc-codegen-cranelift --toolchain nightly-2025-12-10
+```
+
+Linux development builds also require `clang` and `mold` on `PATH`. If Cargo
+reports an unknown codegen backend, a missing `rustc-codegen-cranelift`
+component, or a linker error mentioning `mold`, check these prerequisites
+before investigating the workspace itself. CI disables Cranelift only for
+coverage generation because LLVM coverage instrumentation expects the standard
+LLVM backend.
+
 ## Configuration
 
 Dear Diary reads from environment variables or a `.env` file:

--- a/README.md
+++ b/README.md
@@ -69,26 +69,6 @@ export COLLECTION_NAME="my-memories"
 Connect via MCP stdio transport. The server speaks JSON-RPC 2.0, like all
 well-mannered protocols should.
 
-## Toolchain prerequisites
-
-This workspace uses the pinned Nightly toolchain from `rust-toolchain.toml`.
-Development builds use the Cranelift code generation backend, and Linux
-`x86_64-unknown-linux-gnu` builds link through `clang` with `mold`.
-
-Install the pinned Rust toolchain components with:
-
-```bash
-rustup toolchain install nightly-2025-12-10
-rustup component add rustc-codegen-cranelift --toolchain nightly-2025-12-10
-```
-
-Linux development builds also require `clang` and `mold` on `PATH`. If Cargo
-reports an unknown codegen backend, a missing `rustc-codegen-cranelift`
-component, or a linker error mentioning `mold`, check these prerequisites
-before investigating the workspace itself. CI disables Cranelift only for
-coverage generation through the shared coverage action because LLVM coverage
-instrumentation expects the standard LLVM backend.
-
 ## Configuration
 
 Dear Diary reads from environment variables or a `.env` file:

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Linux development builds also require `clang` and `mold` on `PATH`. If Cargo
 reports an unknown codegen backend, a missing `rustc-codegen-cranelift`
 component, or a linker error mentioning `mold`, check these prerequisites
 before investigating the workspace itself. CI disables Cranelift only for
-coverage generation because LLVM coverage instrumentation expects the standard
-LLVM backend.
+coverage generation through the shared coverage action because LLVM coverage
+instrumentation expects the standard LLVM backend.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ something you have already forgotten a thousand times.
 
 **Dear Diary** understands.
 
-## What is this?
+## Core functionality
 
 Dear Diary is a [Model Context Protocol](https://modelcontextprotocol.io/)
 (MCP) server that provides AI coding agents with persistent semantic memory.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -45,13 +45,17 @@ Install `clang` and `mold` before running local Linux builds that use that host
 target. In GitHub Actions, the CI and release workflows install both packages
 on Linux runners before invoking Cargo.
 
-Coverage generation is the intentional exception to Cranelift. `cargo-llvm-cov`
-requires LLVM coverage instrumentation, so CI uses the shared
-`generate-coverage` action revision that carries the LLVM backend carve-out for
-coverage runs. Do not add a step-level
-`CARGO_PROFILE_DEV_CODEGEN_BACKEND=llvm` override: that environment also
-affects the action's internal tool installation and can make Cargo reject the
-unstable profile setting before coverage starts.
+### CI and coverage
+
+Coverage generation is the intentional exception to Cranelift. CI measures Rust
+coverage with the shared `generate-coverage` action. Coverage runs use the LLVM
+backend instead of Cranelift because `cargo-llvm-cov` relies on LLVM coverage
+instrumentation.
+
+Keep that LLVM instrumentation carve-out inside the shared coverage action. Do
+not add a workflow-level or step-level `CARGO_PROFILE_DEV_CODEGEN_BACKEND=llvm`
+override: that environment can leak into tool installation before coverage
+starts.
 
 Any change to `.cargo/config.toml`, `rust-toolchain.toml`, or the build-related
 GitHub Actions wiring must include script-test coverage that verifies the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2,6 +2,62 @@
 
 This guide covers release automation and local validation for contributors.
 
+## Build configuration
+
+The workspace uses the pinned Nightly toolchain declared in
+`rust-toolchain.toml`. Nightly is required for the Rust 2024 edition and for
+Cargo's unstable `codegen-backend` profile configuration.
+
+Development builds use the Cranelift code generation backend through
+`.cargo/config.toml`:
+
+```toml
+[unstable]
+codegen-backend = true
+
+[profile.dev]
+codegen-backend = "cranelift"
+```
+
+The pinned toolchain must include these Rust components:
+
+- `rustfmt`
+- `clippy`
+- `rustc-codegen-cranelift`
+
+Install or repair the pinned toolchain with:
+
+```bash
+rustup toolchain install nightly-2025-12-10
+rustup component add rustc-codegen-cranelift --toolchain nightly-2025-12-10
+```
+
+Linux `x86_64-unknown-linux-gnu` builds link through `clang` with `mold`:
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+```
+
+Install `clang` and `mold` before running local Linux builds that use that host
+target. In GitHub Actions, the CI and release workflows install both packages
+before invoking Cargo.
+
+Coverage generation is the intentional exception to Cranelift. `cargo-llvm-cov`
+requires LLVM coverage instrumentation, so CI uses the shared
+`generate-coverage` action revision that carries the LLVM backend carve-out for
+coverage runs. Do not add a step-level
+`CARGO_PROFILE_DEV_CODEGEN_BACKEND=llvm` override: that environment also
+affects the action's internal tool installation and can make Cargo reject the
+unstable profile setting before coverage starts.
+
+Any change to `.cargo/config.toml`, `rust-toolchain.toml`, or the build-related
+GitHub Actions wiring must include script-test coverage that verifies the
+configuration contract. At minimum, tests should cover the selected codegen
+backend, the Cranelift component, the Linux linker settings, CI installation of
+`clang` and `mold`, and the coverage action carve-out.
+
 ## Release workflow
 
 The release workflow is defined in `.github/workflows/release.yml`. It runs

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -25,11 +25,12 @@ The pinned toolchain must include these Rust components:
 - `clippy`
 - `rustc-codegen-cranelift`
 
-Install or repair the pinned toolchain with:
+Install or repair the pinned toolchain using `rust-toolchain.toml` as the
+channel source of truth:
 
 ```bash
-rustup toolchain install nightly-2025-12-10
-rustup component add rustc-codegen-cranelift --toolchain nightly-2025-12-10
+rustup toolchain install
+rustup component add rustc-codegen-cranelift
 ```
 
 Linux `x86_64-unknown-linux-gnu` builds link through `clang` with `mold`:
@@ -42,7 +43,7 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 Install `clang` and `mold` before running local Linux builds that use that host
 target. In GitHub Actions, the CI and release workflows install both packages
-before invoking Cargo.
+on Linux runners before invoking Cargo.
 
 Coverage generation is the intentional exception to Cranelift. `cargo-llvm-cov`
 requires LLVM coverage instrumentation, so CI uses the shared
@@ -55,8 +56,8 @@ unstable profile setting before coverage starts.
 Any change to `.cargo/config.toml`, `rust-toolchain.toml`, or the build-related
 GitHub Actions wiring must include script-test coverage that verifies the
 configuration contract. At minimum, tests should cover the selected codegen
-backend, the Cranelift component, the Linux linker settings, CI installation of
-`clang` and `mold`, and the coverage action carve-out.
+backend, the Cranelift component, the Linux linker settings, guarded CI
+installation of `clang` and `mold`, and the coverage action carve-out.
 
 ## Release workflow
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -23,14 +23,14 @@ The pinned toolchain must include these Rust components:
 
 - `rustfmt`
 - `clippy`
-- `rustc-codegen-cranelift`
+- `rustc-codegen-cranelift-preview`
 
 Install or repair the pinned toolchain using `rust-toolchain.toml` as the
 channel source of truth:
 
 ```bash
 rustup toolchain install
-rustup component add rustc-codegen-cranelift
+rustup component add rustc-codegen-cranelift-preview
 ```
 
 Linux `x86_64-unknown-linux-gnu` builds link through `clang` with `mold`:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -19,6 +19,10 @@ codegen-backend = true
 codegen-backend = "cranelift"
 ```
 
+This follows the build profile adopted in Weaver and Gauss, where Cranelift for
+development code generation and `mold` for Linux linking produced useful build
+performance improvements without changing the release artefact contract.
+
 The pinned toolchain must include these Rust components:
 
 - `rustfmt`

--- a/docs/qdrant-client-intro.md
+++ b/docs/qdrant-client-intro.md
@@ -39,7 +39,9 @@ let client = Qdrant::from_url("http://localhost:6334")
 
 ### Creating a Collection
 
-Qdrant organizes data into [collections][collections] of [points][points].
+Qdrant organizes data into
+[collections](https://qdrant.tech/documentation/concepts/collections/) of
+[points](https://qdrant.tech/documentation/concepts/points/).
 
 ```rust
 use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};
@@ -217,10 +219,7 @@ snapshots, consult the extended `Qdrant` client methods.
 
 ## Further reading
 
-- [Collections][collections]
-- [Points][points]
+- [Collections](https://qdrant.tech/documentation/concepts/collections/)
+- [Points](https://qdrant.tech/documentation/concepts/points/)
 - [Payload](https://qdrant.tech/documentation/concepts/payload/)
 - [Search](https://qdrant.tech/documentation/concepts/search/)
-
-[collections]: https://qdrant.tech/documentation/concepts/collections/
-[points]: https://qdrant.tech/documentation/concepts/points/

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -1136,11 +1136,12 @@ i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester
 unic-langid = "0.9"
 ```
 
-The crate exposes the embedded assets via the [`Localizations`] helper. This
-type implements `i18n_embed::I18nAssets`, allowing applications with existing
-Fluent infrastructure to load resources into their own
-[`FluentLanguageLoader`]. Libraries without a localization framework can rely
-on the built-in loader and request a different language at runtime:
+The crate exposes the embedded assets via the
+[`Localizations`](https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/)
+helper. This type implements `i18n_embed::I18nAssets`, allowing applications
+with existing Fluent infrastructure to load resources into their own
+`FluentLanguageLoader`. Libraries without a localization framework can rely on
+the built-in loader and request a different language at runtime:
 
 ```rust,no_run
 # fn scope_locale() -> Result<(), rstest_bdd::localization::LocalizationError> {
@@ -1158,10 +1159,6 @@ translation and continues to fall back to English when a requested locale is
 not shipped with the crate. Procedural macro diagnostics remain in English so
 compile-time output stays deterministic regardless of the host machine’s
 language settings.
-
-[`Localizations`]: https://docs.rs/rstest-bdd/latest/rstest_bdd/localization/
-[`FluentLanguageLoader`]:
-https://docs.rs/i18n-embed/latest/i18n_embed/fluent/struct.FluentLanguageLoader.html
 
 ## Diagnostic tooling
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -64,17 +64,6 @@ Run the test suite to confirm the installation:
 cargo test --workspace
 ```
 
-### CI and coverage
-
-CI measures Rust coverage with the shared `generate-coverage` action. Coverage
-runs use the LLVM backend instead of Cranelift because `cargo-llvm-cov` relies
-on LLVM coverage instrumentation.
-
-Keep that LLVM instrumentation carve-out inside the shared coverage action. Do
-not add a workflow-level or step-level `CARGO_PROFILE_DEV_CODEGEN_BACKEND=llvm`
-override: that environment can leak into tool installation before coverage
-starts.
-
 ## Configuration
 
 Dear Diary is configured through environment variables. These may be set

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -411,7 +411,8 @@ This may take a few moments depending on network speed.
 ### Alternative models
 
 Configure a different model via the `EMBEDDING_MODEL` environment variable.
-Consult the [FastEmbed documentation][fastembed] for available models.
+Consult the [FastEmbed documentation](https://github.com/Qdrant/fastembed) for
+available models.
 
 ## Read-only mode
 
@@ -523,7 +524,8 @@ filtering on specific fields. When entries are stored with metadata, the
 specified fields become searchable through Qdrant's native filtering
 capabilities.
 
-**Tracking**: This limitation is tracked in [GitHub issue `#2`][filter-parsing-issue].
+**Tracking**: This limitation is tracked in
+[GitHub issue `#2`](https://github.com/leynos/dear-diary/issues/2).
 
 ______________________________________________________________________
 
@@ -533,6 +535,3 @@ ______________________________________________________________________
 
 [^3]: Arbitrary filter support requires additional configuration and is not
     enabled by default. See "Known limitations" for details.
-
-[fastembed]: https://github.com/Qdrant/fastembed
-[filter-parsing-issue]: https://github.com/leynos/dear-diary/issues/2

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -64,6 +64,17 @@ Run the test suite to confirm the installation:
 cargo test --workspace
 ```
 
+### CI and coverage
+
+Continuous integration measures Rust coverage through the shared
+`generate-coverage` action. Coverage runs use the LLVM backend instead of
+Cranelift because `cargo-llvm-cov` relies on LLVM coverage instrumentation.
+
+Keep that LLVM instrumentation carve-out inside the shared coverage action. Do
+not add a workflow-level or step-level `CARGO_PROFILE_DEV_CODEGEN_BACKEND=llvm`
+override: that environment can leak into tool installation before coverage
+starts.
+
 ## Configuration
 
 Dear Diary is configured through environment variables. These may be set

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -66,9 +66,9 @@ cargo test --workspace
 
 ### CI and coverage
 
-Continuous integration measures Rust coverage through the shared
-`generate-coverage` action. Coverage runs use the LLVM backend instead of
-Cranelift because `cargo-llvm-cov` relies on LLVM coverage instrumentation.
+CI measures Rust coverage with the shared `generate-coverage` action. Coverage
+runs use the LLVM backend instead of Cranelift because `cargo-llvm-cov` relies
+on LLVM coverage instrumentation.
 
 Keep that LLVM instrumentation carve-out inside the shared coverage action. Do
 not add a workflow-level or step-level `CARGO_PROFILE_DEV_CODEGEN_BACKEND=llvm`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,4 +5,8 @@
 # 2024 lands in stable Rust, this toolchain should be switched back to the
 # stable channel.
 channel = "nightly-2025-12-10"
-components = ["rustfmt", "clippy"]
+components = [
+    "rustfmt",
+    "clippy",
+    "rustc-codegen-cranelift",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,5 +8,5 @@ channel = "nightly-2025-12-10"
 components = [
     "rustfmt",
     "clippy",
-    "rustc-codegen-cranelift",
+    "rustc-codegen-cranelift-preview",
 ]

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -1,0 +1,79 @@
+"""Tests for repository build and coverage configuration.
+
+These tests cover infrastructure files that affect Cargo code generation,
+linking, and CI coverage behaviour. They keep the Cranelift and mold setup
+from drifting silently because these files are not exercised by Rust unit
+tests directly.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CARGO_CONFIG = PROJECT_ROOT / ".cargo" / "config.toml"
+CI_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "ci.yml"
+DEVELOPERS_GUIDE = PROJECT_ROOT / "docs" / "developers-guide.md"
+README = PROJECT_ROOT / "README.md"
+RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+RUST_TOOLCHAIN = PROJECT_ROOT / "rust-toolchain.toml"
+SHARED_ACTIONS_REVISION = "d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54"
+
+
+def load_toml(path: Path) -> dict[str, object]:
+    """Load a TOML file from the repository as a dictionary."""
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def test_cargo_config_enables_cranelift_and_mold_linking() -> None:
+    """Verify the Cargo profile and Linux linker contract."""
+    cargo_config = load_toml(CARGO_CONFIG)
+    linux_target = cargo_config["target"]["x86_64-unknown-linux-gnu"]
+
+    assert cargo_config["unstable"]["codegen-backend"] is True
+    assert cargo_config["profile"]["dev"]["codegen-backend"] == "cranelift"
+    assert linux_target["linker"] == "clang"
+    assert linux_target["rustflags"] == ["-C", "link-arg=-fuse-ld=mold"]
+
+
+def test_toolchain_installs_cranelift_component() -> None:
+    """Verify the pinned Rust toolchain includes Cranelift codegen."""
+    toolchain = load_toml(RUST_TOOLCHAIN)["toolchain"]
+
+    assert toolchain["channel"] == "nightly-2025-12-10"
+    assert "rustfmt" in toolchain["components"]
+    assert "clippy" in toolchain["components"]
+    assert "rustc-codegen-cranelift" in toolchain["components"]
+
+
+def test_ci_installs_linker_tools_and_uses_coverage_carve_out() -> None:
+    """Verify CI installs linker tools and delegates coverage backend handling."""
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
+    assert f"generate-coverage@{SHARED_ACTIONS_REVISION}" in workflow
+    assert "sudo apt-get install --yes clang mold" in workflow
+    assert "CARGO_PROFILE_DEV_CODEGEN_BACKEND" not in workflow
+
+
+def test_release_workflow_installs_linker_tools() -> None:
+    """Verify release builds have the Linux linker prerequisites available."""
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
+    assert "sudo apt-get install --yes clang mold" in workflow
+    assert 'RUSTFLAGS: ""' in workflow
+
+
+def test_build_configuration_is_developer_documentation() -> None:
+    """Verify build-system details live in developer documentation."""
+    developer_docs = DEVELOPERS_GUIDE.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    assert "## Build configuration" in developer_docs
+    assert "Cranelift code generation backend" in developer_docs
+    assert "`clang` with `mold`" in developer_docs
+    assert "LLVM backend carve-out" in developer_docs
+    assert "Toolchain prerequisites" not in readme
+    assert "rustc-codegen-cranelift" not in readme

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -45,12 +45,27 @@ def named_workflow_step(workflow: str, name: str) -> str:
 def load_text(path: Path) -> str:
     """Load a text file from the repository.
 
+    Parameters
+    ----------
+    path
+        Repository file path to read as UTF-8 text.
+
+    Returns
+    -------
+    str
+        The decoded file contents.
+
     Raises
     ------
     FileNotFoundError
         If `path` does not exist.
     UnicodeDecodeError
         If `path` is not valid UTF-8 text.
+
+    Examples
+    --------
+    >>> load_text(README).startswith("#")
+    True
     """
     return path.read_text(encoding="utf-8")
 
@@ -58,12 +73,27 @@ def load_text(path: Path) -> str:
 def load_toml(path: Path) -> dict[str, object]:
     """Load a TOML file from the repository as a dictionary.
 
+    Parameters
+    ----------
+    path
+        Repository TOML file path to read and parse.
+
+    Returns
+    -------
+    dict[str, object]
+        Parsed TOML document contents.
+
     Raises
     ------
     FileNotFoundError
         If `path` does not exist.
     tomllib.TOMLDecodeError
         If `path` contains invalid TOML.
+
+    Examples
+    --------
+    >>> load_toml(RUST_TOOLCHAIN)["toolchain"]["components"]
+    ['rustfmt', 'clippy', 'rustc-codegen-cranelift-preview']
     """
     return tomllib.loads(load_text(path))
 
@@ -144,6 +174,7 @@ def test_build_configuration_is_developer_documentation() -> None:
     assert "## Build configuration" in developer_docs
     assert "### CI and coverage" in developer_docs
     assert "Cranelift code generation backend" in developer_docs
+    assert "Weaver and Gauss" in developer_docs
     assert "`clang` with `mold`" in developer_docs
     assert "LLVM instrumentation carve-out" in developer_docs
     assert "shared `generate-coverage` action" in developer_docs

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -18,6 +18,7 @@ DEVELOPERS_GUIDE = PROJECT_ROOT / "docs" / "developers-guide.md"
 README = PROJECT_ROOT / "README.md"
 RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
 RUST_TOOLCHAIN = PROJECT_ROOT / "rust-toolchain.toml"
+USER_GUIDE = PROJECT_ROOT / "docs" / "users-guide.md"
 SHARED_ACTIONS_REVISION = "d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54"
 
 
@@ -80,11 +81,16 @@ def test_build_configuration_is_developer_documentation() -> None:
     """Verify build-system details live in developer documentation."""
     developer_docs = DEVELOPERS_GUIDE.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
+    user_guide = USER_GUIDE.read_text(encoding="utf-8")
 
     assert "## Build configuration" in developer_docs
     assert "Cranelift code generation backend" in developer_docs
     assert "`clang` with `mold`" in developer_docs
     assert "LLVM backend carve-out" in developer_docs
     assert "nightly-2025-12-10" not in developer_docs
+    assert "## Core functionality" in readme
     assert "Toolchain prerequisites" not in readme
     assert "rustc-codegen-cranelift" not in readme
+    assert "CI and coverage" in user_guide
+    assert "shared coverage action" in user_guide
+    assert "LLVM coverage instrumentation" in user_guide

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 CARGO_CONFIG = PROJECT_ROOT / ".cargo" / "config.toml"
 CI_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "ci.yml"
@@ -20,6 +22,19 @@ RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
 RUST_TOOLCHAIN = PROJECT_ROOT / "rust-toolchain.toml"
 USER_GUIDE = PROJECT_ROOT / "docs" / "users-guide.md"
 SHARED_ACTIONS_REVISION = "d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54"
+
+
+def load_text(path: Path) -> str:
+    """Load a text file from the repository.
+
+    Raises
+    ------
+    FileNotFoundError
+        If `path` does not exist.
+    UnicodeDecodeError
+        If `path` is not valid UTF-8 text.
+    """
+    return path.read_text(encoding="utf-8")
 
 
 def load_toml(path: Path) -> dict[str, object]:
@@ -32,7 +47,22 @@ def load_toml(path: Path) -> dict[str, object]:
     tomllib.TOMLDecodeError
         If `path` contains invalid TOML.
     """
-    return tomllib.loads(path.read_text(encoding="utf-8"))
+    return tomllib.loads(load_text(path))
+
+
+def test_load_text_reports_missing_file(tmp_path: Path) -> None:
+    """Expose missing file failures from repository text reads."""
+    with pytest.raises(FileNotFoundError):
+        load_text(tmp_path / "missing.txt")
+
+
+def test_load_toml_reports_invalid_toml(tmp_path: Path) -> None:
+    """Expose TOML parse failures from repository configuration reads."""
+    invalid_toml = tmp_path / "invalid.toml"
+    invalid_toml.write_text("not = [valid\n", encoding="utf-8")
+
+    with pytest.raises(tomllib.TOMLDecodeError):
+        load_toml(invalid_toml)
 
 
 def test_cargo_config_enables_cranelift_and_mold_linking() -> None:
@@ -58,10 +88,11 @@ def test_toolchain_installs_cranelift_component() -> None:
 
 def test_ci_installs_linker_tools_and_uses_coverage_carve_out() -> None:
     """Verify CI installs linker tools and delegates coverage backend handling."""
-    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    workflow = load_text(CI_WORKFLOW)
 
     assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
     assert f"generate-coverage@{SHARED_ACTIONS_REVISION}" in workflow
+    assert "run: make test-scripts" in workflow
     assert "if: runner.os == 'Linux'" in workflow
     assert "export DEBIAN_FRONTEND=noninteractive" in workflow
     assert (
@@ -73,7 +104,7 @@ def test_ci_installs_linker_tools_and_uses_coverage_carve_out() -> None:
 
 def test_release_workflow_installs_linker_tools() -> None:
     """Verify release builds have the Linux linker prerequisites available."""
-    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    workflow = load_text(RELEASE_WORKFLOW)
 
     assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
     assert "if: runner.os == 'Linux'" in workflow
@@ -87,8 +118,8 @@ def test_release_workflow_installs_linker_tools() -> None:
 
 def test_build_configuration_is_developer_documentation() -> None:
     """Verify build-system details live in developer documentation."""
-    developer_docs = DEVELOPERS_GUIDE.read_text(encoding="utf-8")
-    readme = README.read_text(encoding="utf-8")
+    developer_docs = load_text(DEVELOPERS_GUIDE)
+    readme = load_text(README)
 
     assert "## Build configuration" in developer_docs
     assert "### CI and coverage" in developer_docs
@@ -102,4 +133,4 @@ def test_build_configuration_is_developer_documentation() -> None:
     assert "## Core functionality" in readme
     assert "Toolchain prerequisites" not in readme
     assert "rustc-codegen-cranelift" not in readme
-    assert "CI and coverage" not in USER_GUIDE.read_text(encoding="utf-8")
+    assert "CI and coverage" not in load_text(USER_GUIDE)

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -41,7 +41,7 @@ def test_toolchain_installs_cranelift_component() -> None:
     """Verify the pinned Rust toolchain includes Cranelift codegen."""
     toolchain = load_toml(RUST_TOOLCHAIN)["toolchain"]
 
-    assert toolchain["channel"] == "nightly-2025-12-10"
+    assert toolchain["channel"].startswith("nightly-")
     assert "rustfmt" in toolchain["components"]
     assert "clippy" in toolchain["components"]
     assert "rustc-codegen-cranelift" in toolchain["components"]
@@ -53,7 +53,12 @@ def test_ci_installs_linker_tools_and_uses_coverage_carve_out() -> None:
 
     assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
     assert f"generate-coverage@{SHARED_ACTIONS_REVISION}" in workflow
-    assert "sudo apt-get install --yes clang mold" in workflow
+    assert "if: runner.os == 'Linux'" in workflow
+    assert "export DEBIAN_FRONTEND=noninteractive" in workflow
+    assert (
+        "sudo apt-get install --yes --no-install-recommends clang mold"
+        in workflow
+    )
     assert "CARGO_PROFILE_DEV_CODEGEN_BACKEND" not in workflow
 
 
@@ -62,7 +67,12 @@ def test_release_workflow_installs_linker_tools() -> None:
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
     assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
-    assert "sudo apt-get install --yes clang mold" in workflow
+    assert "if: runner.os == 'Linux'" in workflow
+    assert "export DEBIAN_FRONTEND=noninteractive" in workflow
+    assert (
+        "sudo apt-get install --yes --no-install-recommends clang mold"
+        in workflow
+    )
     assert 'RUSTFLAGS: ""' in workflow
 
 
@@ -75,5 +85,6 @@ def test_build_configuration_is_developer_documentation() -> None:
     assert "Cranelift code generation backend" in developer_docs
     assert "`clang` with `mold`" in developer_docs
     assert "LLVM backend carve-out" in developer_docs
+    assert "nightly-2025-12-10" not in developer_docs
     assert "Toolchain prerequisites" not in readme
     assert "rustc-codegen-cranelift" not in readme

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -23,6 +23,10 @@ RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
 RUST_TOOLCHAIN = PROJECT_ROOT / "rust-toolchain.toml"
 USER_GUIDE = PROJECT_ROOT / "docs" / "users-guide.md"
 SHARED_ACTIONS_REVISION = "d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54"
+HARDENED_LINKER_INSTALL_COMMAND = (
+    "apt-get update && sudo apt-get install --yes --no-install-recommends "
+    "clang mold"
+)
 
 
 def named_workflow_step(workflow: str, name: str) -> str:
@@ -40,6 +44,22 @@ def named_workflow_step(workflow: str, name: str) -> str:
     matches = pattern.findall(workflow)
     assert len(matches) == 1
     return matches[0]
+
+
+def normalise_shell_continuations(script: str) -> str:
+    """Collapse shell line continuations so command sequences are assertable.
+
+    Parameters
+    ----------
+    script
+        Shell script text from a workflow step.
+
+    Returns
+    -------
+    str
+        Script text with ``\\ &&`` line continuations collapsed.
+    """
+    return re.sub(r"\s*\\\n\s*&&\s*", " && ", script)
 
 
 def load_text(path: Path) -> str:
@@ -144,9 +164,8 @@ def test_ci_installs_linker_tools_and_uses_coverage_carve_out() -> None:
     linker_step = named_workflow_step(workflow, "Install mold linker")
     assert "if: runner.os == 'Linux'" in linker_step
     assert "export DEBIAN_FRONTEND=noninteractive" in linker_step
-    assert (
-        "sudo apt-get install --yes --no-install-recommends clang mold"
-        in linker_step
+    assert HARDENED_LINKER_INSTALL_COMMAND in normalise_shell_continuations(
+        linker_step
     )
     assert "CARGO_PROFILE_DEV_CODEGEN_BACKEND" not in workflow
 
@@ -159,9 +178,8 @@ def test_release_workflow_installs_linker_tools() -> None:
     linker_step = named_workflow_step(workflow, "Install mold linker")
     assert "if: runner.os == 'Linux'" in linker_step
     assert "export DEBIAN_FRONTEND=noninteractive" in linker_step
-    assert (
-        "sudo apt-get install --yes --no-install-recommends clang mold"
-        in linker_step
+    assert HARDENED_LINKER_INSTALL_COMMAND in normalise_shell_continuations(
+        linker_step
     )
     assert 'RUSTFLAGS: ""' in workflow
 
@@ -180,7 +198,7 @@ def test_build_configuration_is_developer_documentation() -> None:
     assert "shared `generate-coverage` action" in developer_docs
     assert "LLVM coverage" in developer_docs
     assert "instrumentation" in developer_docs
-    assert "nightly-2025-12-10" not in developer_docs
+    assert re.search(r"nightly-\d{4}-\d{2}-\d{2}", developer_docs) is None
     assert "## Core functionality" in readme
     assert "Toolchain prerequisites" not in readme
     assert "rustc-codegen-cranelift" not in readme

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -23,7 +23,15 @@ SHARED_ACTIONS_REVISION = "d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54"
 
 
 def load_toml(path: Path) -> dict[str, object]:
-    """Load a TOML file from the repository as a dictionary."""
+    """Load a TOML file from the repository as a dictionary.
+
+    Raises
+    ------
+    FileNotFoundError
+        If `path` does not exist.
+    tomllib.TOMLDecodeError
+        If `path` contains invalid TOML.
+    """
     return tomllib.loads(path.read_text(encoding="utf-8"))
 
 
@@ -81,16 +89,17 @@ def test_build_configuration_is_developer_documentation() -> None:
     """Verify build-system details live in developer documentation."""
     developer_docs = DEVELOPERS_GUIDE.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
-    user_guide = USER_GUIDE.read_text(encoding="utf-8")
 
     assert "## Build configuration" in developer_docs
+    assert "### CI and coverage" in developer_docs
     assert "Cranelift code generation backend" in developer_docs
     assert "`clang` with `mold`" in developer_docs
-    assert "LLVM backend carve-out" in developer_docs
+    assert "LLVM instrumentation carve-out" in developer_docs
+    assert "shared `generate-coverage` action" in developer_docs
+    assert "LLVM coverage" in developer_docs
+    assert "instrumentation" in developer_docs
     assert "nightly-2025-12-10" not in developer_docs
     assert "## Core functionality" in readme
     assert "Toolchain prerequisites" not in readme
     assert "rustc-codegen-cranelift" not in readme
-    assert "CI and coverage" in user_guide
-    assert "shared `generate-coverage` action" in user_guide
-    assert "LLVM coverage instrumentation" in user_guide
+    assert "CI and coverage" not in USER_GUIDE.read_text(encoding="utf-8")

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -8,6 +8,7 @@ tests directly.
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -22,6 +23,23 @@ RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
 RUST_TOOLCHAIN = PROJECT_ROOT / "rust-toolchain.toml"
 USER_GUIDE = PROJECT_ROOT / "docs" / "users-guide.md"
 SHARED_ACTIONS_REVISION = "d400b079fb6a8fa92f7e7b6c57f3d1c92a4b2d54"
+
+
+def named_workflow_step(workflow: str, name: str) -> str:
+    """Return one named workflow step block.
+
+    Raises
+    ------
+    AssertionError
+        If `workflow` does not contain exactly one step named `name`.
+    """
+    pattern = re.compile(
+        rf"(?ms)^      - name: {re.escape(name)}\n"
+        r".*?(?=^      - (?:name|uses): |^    [A-Za-z_-]+:|\Z)"
+    )
+    matches = pattern.findall(workflow)
+    assert len(matches) == 1
+    return matches[0]
 
 
 def load_text(path: Path) -> str:
@@ -93,11 +111,12 @@ def test_ci_installs_linker_tools_and_uses_coverage_carve_out() -> None:
     assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
     assert f"generate-coverage@{SHARED_ACTIONS_REVISION}" in workflow
     assert "run: make test-scripts" in workflow
-    assert "if: runner.os == 'Linux'" in workflow
-    assert "export DEBIAN_FRONTEND=noninteractive" in workflow
+    linker_step = named_workflow_step(workflow, "Install mold linker")
+    assert "if: runner.os == 'Linux'" in linker_step
+    assert "export DEBIAN_FRONTEND=noninteractive" in linker_step
     assert (
         "sudo apt-get install --yes --no-install-recommends clang mold"
-        in workflow
+        in linker_step
     )
     assert "CARGO_PROFILE_DEV_CODEGEN_BACKEND" not in workflow
 
@@ -107,11 +126,12 @@ def test_release_workflow_installs_linker_tools() -> None:
     workflow = load_text(RELEASE_WORKFLOW)
 
     assert f"setup-rust@{SHARED_ACTIONS_REVISION}" in workflow
-    assert "if: runner.os == 'Linux'" in workflow
-    assert "export DEBIAN_FRONTEND=noninteractive" in workflow
+    linker_step = named_workflow_step(workflow, "Install mold linker")
+    assert "if: runner.os == 'Linux'" in linker_step
+    assert "export DEBIAN_FRONTEND=noninteractive" in linker_step
     assert (
         "sudo apt-get install --yes --no-install-recommends clang mold"
-        in workflow
+        in linker_step
     )
     assert 'RUSTFLAGS: ""' in workflow
 

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -44,7 +44,7 @@ def test_toolchain_installs_cranelift_component() -> None:
     assert toolchain["channel"].startswith("nightly-")
     assert "rustfmt" in toolchain["components"]
     assert "clippy" in toolchain["components"]
-    assert "rustc-codegen-cranelift" in toolchain["components"]
+    assert "rustc-codegen-cranelift-preview" in toolchain["components"]
 
 
 def test_ci_installs_linker_tools_and_uses_coverage_carve_out() -> None:

--- a/scripts/tests/test_build_configuration.py
+++ b/scripts/tests/test_build_configuration.py
@@ -92,5 +92,5 @@ def test_build_configuration_is_developer_documentation() -> None:
     assert "Toolchain prerequisites" not in readme
     assert "rustc-codegen-cranelift" not in readme
     assert "CI and coverage" in user_guide
-    assert "shared coverage action" in user_guide
+    assert "shared `generate-coverage` action" in user_guide
     assert "LLVM coverage instrumentation" in user_guide


### PR DESCRIPTION
Enable the Cranelift backend for development builds and route Linux host linking through `clang` and `mold` to match the Weaver build profile. Add the required toolchain component and CI linker installation so the configuration works both locally and in GitHub Actions.

Keep coverage generation on the LLVM backend because the coverage action expects LLVM instrumentation. Document the prerequisites and repair stale Markdown references that blocked the project Markdown gates.

## Summary by Sourcery

Adopt the Cranelift backend for development builds and align Linux linking with clang and mold while updating CI, toolchain configuration, and documentation to match.

Build:
- Enable Cranelift as the dev profile codegen backend and configure Linux targets to link via clang with mold.
- Add the rustc-codegen-cranelift component to the pinned Rust nightly toolchain configuration.

CI:
- Update shared CI action revisions and install clang and mold in CI for both test/coverage and release workflows.

Documentation:
- Document Rust nightly, Cranelift, and clang/mold prerequisites for development builds.
- Fix and inline external documentation links in the rstest-bdd, Qdrant client, and user guides.