### PR TITLE
Align the Whitaker CI install step with the estate-wide pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_REV: f768c2e53c47df13658af1168a67851d388750bf
+      WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Setup Rust
@@ -36,25 +36,24 @@ jobs:
             !**/dist/**
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
-      - name: Cache Whitaker installation
-        id: cache-whitaker
+      - name: Cache Whitaker installer
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ~/.cargo/bin/whitaker-installer
-            ~/.local/bin/whitaker
-            ~/.dylint_drivers
-            ~/.local/share/whitaker
-          key: whitaker-v2-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_REV }}
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
       - name: Script tests
         run: make test-scripts
       - name: Install Whitaker
         run: |
-          if [ "${{ steps.cache-whitaker.outputs.cache-hit }}" != "true" ]; then
-            cargo install --locked \
-              --git https://github.com/leynos/whitaker \
-              --rev "${WHITAKER_INSTALLER_REV}" \
-              whitaker-installer
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
           fi
           whitaker-installer --cranelift
       - name: Lint

--- a/docs/adr-001-whitaker-lint-contract.md
+++ b/docs/adr-001-whitaker-lint-contract.md
@@ -22,9 +22,10 @@ startup configuration behaviour difficult to review.
 
 The project adopts Whitaker as part of the local and CI lint contract. The
 `make lint` target runs Rustdoc, Clippy, and Whitaker. Continuous Integration
-(CI) installs the pinned Whitaker installer revision and runs
+(CI) installs the versioned `whitaker-installer` release from crates.io and runs
 `whitaker-installer --cranelift` immediately before `make lint`, matching the
-same contract contributors run locally.
+same contract contributors run locally. The suite itself follows the rolling
+Whitaker release.
 
 Whitaker findings are treated as design feedback. When the suite reports
 complexity in production code, the preferred response is to extract named
@@ -36,7 +37,7 @@ panicking or hiding fallibility.
 ## Consequences
 
 - Pull requests must keep Rustdoc, Clippy, and Whitaker green before review.
-- CI takes on an additional setup step for the pinned Whitaker installer.
+- CI takes on an additional setup step for the versioned Whitaker installer.
 - Refactors driven by Bumpy Road findings should favour small private helpers
   over lint suppressions.
 - Test helpers must avoid `.expect()` outside recognized test bodies; when a

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -38,13 +38,13 @@ rustup component add rustc-codegen-cranelift-preview
 ```
 
 `make lint` runs Rustdoc, Clippy, and Whitaker. Install Whitaker through the
-upstream installer before running the full lint target locally:
+versioned installer from crates.io before running the full lint target locally
+(CI pins the same installer version through the `WHITAKER_INSTALLER_VERSION`
+environment variable in `.github/workflows/ci.yml`; the suite itself follows
+the rolling Whitaker release):
 
 ```bash
-cargo install --locked \
-  --git https://github.com/leynos/whitaker \
-  --rev f768c2e53c47df13658af1168a67851d388750bf \
-  whitaker-installer
+cargo install --locked whitaker-installer --version 0.2.5
 whitaker-installer --cranelift
 ```
 


### PR DESCRIPTION
## Summary

This pull request brings dear-diary's Whitaker Dylint integration in line with the estate-wide rollout pattern (see leynos/netsuke#410). The repository already ran the suite in `make lint`; however, CI installed `whitaker-installer` from a pinned git revision that predates its crates.io release, and cached the built suite artefacts against that fixed key, which defeated the rolling suite release.

CI now pins `whitaker-installer` 0.2.5 through a job-level `WHITAKER_INSTALLER_VERSION` environment variable (expanded as a plain shell variable inside the run block), prefers `cargo binstall` with a `cargo install` fallback, and caches only the installer binary and binstall download cache keyed on OS, architecture, and installer version. The `--cranelift` installer flag is retained to match the workspace's Cranelift dev codegen backend. The suite itself runs clean across the workspace, so no code changes or `dylint.toml` exclusions were needed.

## Review walkthrough

- [.github/workflows/ci.yml](https://github.com/leynos/dear-diary/blob/adopt-whitaker/.github/workflows/ci.yml): replaced the git-revision install and suite-artefact cache with the estate-standard versioned installer step and installer-only cache.

## Validation

- `RUSTFLAGS="-D warnings" whitaker --all -- --workspace --all-targets --all-features` exits 0 with no findings.
- `make check-fmt lint test test-scripts markdownlint` passes (10 Rust test targets, 16 Python script tests, 0 failures).
- `make nixie` validates all Mermaid diagrams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
